### PR TITLE
V1 Algorithm refactor 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ site/
 uv.lock
 
 _dev**
+**/TODO.md

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dev*.ipynb
 .vscode
 site/
 uv.lock
+
+_dev**

--- a/src/jaxnasium/__init__.py
+++ b/src/jaxnasium/__init__.py
@@ -4,6 +4,7 @@ __version__ = version("jaxnasium")
 from jaxnasium import _registry, envs as envs, tree as tree
 
 from ._environment import (
+    ORIGINAL_OBSERVATION_KEY as ORIGINAL_OBSERVATION_KEY,
     Environment as Environment,
     EnvState as EnvState,
     TimeStep as TimeStep,

--- a/src/jaxnasium/algorithms/__init__.py
+++ b/src/jaxnasium/algorithms/__init__.py
@@ -1,17 +1,19 @@
 try:
     # Weird import for proper copy from the CLI
-    from jaxnasium.algorithms._algorithm import RLAlgorithm as RLAlgorithm  # noqa: I001
-
-    from .networks import (
-        ActorNetwork as ActorNetwork,
-        QValueNetwork as QValueNetwork,
-        ValueNetwork as ValueNetwork,
-    )
+    from jaxnasium.algorithms._algorithm import (
+        RLAgent as RLAgent,
+        RLAlgorithm as RLAlgorithm,
+    )  # noqa: I001
 
     from ._dqn import DQN as DQN
     from ._ppo import PPO as PPO
     from ._pqn import PQN as PQN
     from ._sac import SAC as SAC
+    from .networks import (
+        ActorNetwork as ActorNetwork,
+        QValueNetwork as QValueNetwork,
+        ValueNetwork as ValueNetwork,
+    )
 
 except ImportError:
     raise ImportError(

--- a/src/jaxnasium/algorithms/_algorithm.py
+++ b/src/jaxnasium/algorithms/_algorithm.py
@@ -1,11 +1,8 @@
-import copy
-import inspect
 import logging
-import types
 import warnings
 from abc import abstractmethod
-from dataclasses import replace
-from typing import Any, Callable, List, Literal, Optional, Tuple
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Literal, Optional, Tuple
 
 import equinox as eqx
 import jax
@@ -13,23 +10,9 @@ import jax.numpy as jnp
 from jaxtyping import Array, Float, PRNGKeyArray, PyTree
 
 import jaxnasium as jym
-from jaxnasium import (
-    Environment,
-    VecEnvWrapper,
-    is_wrapped,
-    remove_wrapper,
-)
-from jaxnasium.algorithms.utils import transform_multi_agent
+from jaxnasium import Environment, Space, VecEnvWrapper, is_wrapped, remove_wrapper
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_PER_AGENT_FUNCTIONS = [
-    "get_action",
-    "get_value",
-    "_update_agent_state",
-    "_make_agent_state",
-    "_postprocess_rollout",
-]
 
 
 class RLAlgorithm(eqx.Module):
@@ -60,7 +43,7 @@ class RLAlgorithm(eqx.Module):
 
     """
 
-    state: eqx.AbstractVar[PyTree[eqx.Module]]
+    agent: eqx.AbstractVar[PyTree[eqx.Module]]
     "Trainable state of the algorithm, usually containing the networks, optimizer state and optional normalization running statistics."
 
     multi_agent: bool = eqx.field(static=True, default=False)
@@ -74,24 +57,22 @@ class RLAlgorithm(eqx.Module):
 
     @property
     def is_initialized(self) -> bool:
-        return self.state is not None
+        return self.agent is not None
 
     def save_state(self, file_path: str):
         with open(file_path, "wb") as f:
-            eqx.tree_serialise_leaves(f, self.state)
+            eqx.tree_serialise_leaves(f, self.agent)
 
     def load_state(self, file_path: str) -> "RLAlgorithm":
         with open(file_path, "rb") as f:
-            state = eqx.tree_deserialise_leaves(f, self.state)
-        agent = replace(self, state=state)
-        return agent
+            agent = eqx.tree_deserialise_leaves(f, self.agent)
+        algorithm = replace(self, agent=agent)
+        return algorithm
 
-    @staticmethod
-    @abstractmethod
     def get_action(
-        key: PRNGKeyArray, state: Any, observation: PyTree, deterministic: bool
-    ) -> Any:
-        pass
+        self, key: PRNGKeyArray, observation: PyTree, deterministic: bool, **kwargs
+    ):
+        return self.agent.get_action(key, observation, deterministic, **kwargs)
 
     @abstractmethod
     def train(self, key: PRNGKeyArray, env: Environment) -> "RLAlgorithm":
@@ -113,9 +94,7 @@ class RLAlgorithm(eqx.Module):
                 episode_reward, rng, obs, env_state, done = carry
                 rng, action_key, step_key = jax.random.split(rng, 3)
 
-                action = self.get_action(
-                    action_key, self.state, obs, deterministic=True
-                )
+                action = self.get_action(action_key, obs, deterministic=True)
                 (obs, reward, terminated, truncated, info), env_state = env.step(
                     step_key, env_state, action
                 )
@@ -142,48 +121,6 @@ class RLAlgorithm(eqx.Module):
         )
 
         return episode_rewards
-
-    def __make_multi_agent__(
-        self, *, upgrade_func_names: List[str] = DEFAULT_PER_AGENT_FUNCTIONS
-    ):
-        cls = self.__class__
-        new_attrs: dict[str, object] = {}
-
-        for name in upgrade_func_names:
-            try:
-                attr_obj = inspect.getattr_static(cls, name)
-            except AttributeError:
-                if (
-                    name in DEFAULT_PER_AGENT_FUNCTIONS
-                    and upgrade_func_names == DEFAULT_PER_AGENT_FUNCTIONS
-                ):  # If algorithm is just using defaults, then we skip missing methods
-                    # If upgrade_func_names is set, then we expect methods to be present.
-                    continue
-                raise AttributeError(f"Method {name!r} not found in {cls.__name__}. ")
-
-            if isinstance(attr_obj, staticmethod):
-                orig_fn: Callable = attr_obj.__func__
-                new_attrs[name] = staticmethod(transform_multi_agent(orig_fn))
-
-            elif callable(attr_obj) or callable(
-                attr_obj.method
-            ):  # instance or class method
-                orig_fn: Callable = (
-                    attr_obj if callable(attr_obj) else attr_obj.method
-                )  # .method compatibility with older equinox versions
-                new_attrs[name] = transform_multi_agent(orig_fn)
-
-            else:
-                raise TypeError(f"Attribute {name!r} is not a (static/class)method")
-
-        NewCls = types.new_class(
-            f"{cls.__name__}__MultiAgent", (cls,), {}, lambda ns: ns.update(new_attrs)
-        )
-
-        new_instance = copy.copy(self)  # keeps parameters unchanged
-        new_instance = replace(new_instance, multi_agent=True)
-        object.__setattr__(new_instance, "__class__", NewCls)  # safe: NewCls ⊂ cls
-        return new_instance
 
     def __check_env__(self, env: Environment, vectorized: bool = False) -> Environment:
         """
@@ -243,3 +180,79 @@ class RLAlgorithm(eqx.Module):
             env = VecEnvWrapper(env)
 
         return env
+
+
+class HackuinoxModule(type(eqx.Module)):
+    # Temporary name.
+    # Here, we override the regular __call__ of equinox modules to allow __new__ methods of
+    # modules to return something other than an instance of the module class (e.g. a MultiAgentWrapper of multiple instances).
+    # Normally, Equinox will bookkeep what classes should be created and are being created (presumably to keep track of what should be frozen).
+
+    def __call__(cls, *args, **kwargs):
+        # Subclasses with a __new_wrapped__ classmethod can use it to intercept the regular __call__
+        # and return something other than an instance of the class (e.g. a MultiAgentWrapper of multiple instances).
+        # The __new_wrapped__ method should make sure infinite recursion is avoided
+        dispatch = getattr(cls, "__new_wrapped__", None)
+        if dispatch is not None:
+            dispatched_result = dispatch(*args, **kwargs)
+            if dispatched_result:
+                return dispatched_result
+        return super().__call__(*args, **kwargs)
+
+
+class RLAgent(eqx.Module, metaclass=HackuinoxModule):
+    @abstractmethod
+    def __init__(self, key: PRNGKeyArray, env: Environment, trainer: RLAlgorithm):
+        pass
+
+    @classmethod
+    def __new_wrapped__(cls, key: PRNGKeyArray, env: Environment, trainer: RLAlgorithm):
+        @dataclass
+        class SingleAgentEnvView:
+            env: Environment
+            action_space: Space
+            observation_space: Space
+
+            def __getattr__(self, name):
+                return getattr(self.env, name)
+
+        auto_upgrade_multi_agent = getattr(trainer, "auto_upgrade_multi_agent", False)
+        if getattr(env, "multi_agent", False) and auto_upgrade_multi_agent:
+            from .utils._multi_agent import (
+                MultiAgentWrapper,
+                map_multi_agent,
+                to_per_agent,
+            )
+
+            # `map_multi_agent` infers the agent structure from the first non-key argument
+            # As such, we create a per-agent environment (with each environment having the obs/action space of a single agent)
+            agent_structure = jax.tree.structure(env.observation_space)
+            obs_spaces = eqx.tree_flatten_one_level(env.observation_space)[0]
+            action_spaces = eqx.tree_flatten_one_level(env.action_space)[0]
+            envs = [
+                SingleAgentEnvView(env, a, o) for a, o in zip(action_spaces, obs_spaces)
+            ]
+            envs = jax.tree.unflatten(agent_structure, envs)
+
+            # Also create a per-agent trainer that may have per agent hyperparemeters
+            trainer_args = {}
+            for k, value in trainer.__dict__.items():
+                if k == "auto_upgrade_multi_agent":
+                    continue  # prevent infinite recursion
+                trainer_args[k] = to_per_agent(value, agent_structure)
+            trainers = [
+                type(trainer)(
+                    auto_upgrade_multi_agent=False,  # prevent infinite recursion
+                    **{
+                        key: eqx.tree_flatten_one_level(trainer_args[key])[0][i]
+                        for key in trainer_args
+                    },
+                )
+                for i in range(agent_structure.num_leaves)
+            ]
+            trainers = jax.tree.unflatten(agent_structure, trainers)
+
+            return MultiAgentWrapper(
+                map_multi_agent(lambda k, e, t: cls(k, e, t), key, envs, trainers)
+            )
+        return None  # continue with regular __call__

--- a/src/jaxnasium/algorithms/_algorithm.py
+++ b/src/jaxnasium/algorithms/_algorithm.py
@@ -70,7 +70,11 @@ class RLAlgorithm(eqx.Module):
         return algorithm
 
     def get_action(
-        self, key: PRNGKeyArray, observation: PyTree, deterministic: bool, **kwargs
+        self,
+        key: PRNGKeyArray,
+        observation: PyTree,
+        deterministic: bool = False,
+        **kwargs,
     ):
         return self.agent.get_action(key, observation, deterministic, **kwargs)
 

--- a/src/jaxnasium/algorithms/_algorithm.py
+++ b/src/jaxnasium/algorithms/_algorithm.py
@@ -205,6 +205,10 @@ class RLAgent(eqx.Module, metaclass=HackuinoxModule):
     def __init__(self, key: PRNGKeyArray, env: Environment, trainer: RLAlgorithm):
         pass
 
+    def replace(self, **updates):
+        keys, values = zip(*updates.items())
+        return eqx.tree_at(lambda c: [c.__dict__[key] for key in keys], self, values)
+
     @classmethod
     def __new_wrapped__(cls, key: PRNGKeyArray, env: Environment, trainer: RLAlgorithm):
         @dataclass

--- a/src/jaxnasium/algorithms/_dqn.py
+++ b/src/jaxnasium/algorithms/_dqn.py
@@ -93,18 +93,6 @@ class DQNAgent(RLAgent):
             q_loss = optax.huber_loss(q_taken, target)
             return jym.tree.mean(q_loss)
 
-        # obs, next_obs, reward = (
-        #     batch.observation,
-        #     batch.next_observation,
-        #     batch.reward,
-        # )
-        # batch = replace(
-        #     batch,
-        #     observation=self.normalizer.normalize_obs(obs),
-        #     next_observation=self.normalizer.normalize_obs(next_obs),
-        #     reward=self.normalizer.normalize_reward(reward),
-        # )
-
         # Compute target
         q_target_output = jax.vmap(self.critic_target)(batch.next_observation)
         q_target_output = jym.tree.batch_sum(

--- a/src/jaxnasium/algorithms/_dqn.py
+++ b/src/jaxnasium/algorithms/_dqn.py
@@ -80,15 +80,65 @@ class DQNAgent(RLAgent):
         observation = self.normalizer.normalize_obs(observation)
         return self.critic(observation)
 
-    def update_normalizer(self, trajectory_batch: Transition):
-        updated_normalizer = self.normalizer.update(trajectory_batch)
-        return self.replace(normalizer=updated_normalizer)
-
     def normalize_observation(self, observations: PyTree):
         return self.normalizer.normalize_obs(observations)
 
     def normalize_reward(self, rewards: PyTree):
         return self.normalizer.normalize_reward(rewards)
+
+    def update_normalizer(self, trajectory_batch: Transition):
+        updated_normalizer = self.normalizer.update(trajectory_batch)
+        return self.replace(normalizer=updated_normalizer)
+
+    def update_params(self, trajectory_batch: Transition, trainer: "DQN"):
+        @eqx.filter_grad
+        def __dqn_loss(params: QValueNetwork, train_batch: Transition):
+            q_out_1 = jax.vmap(params)(train_batch.observation)
+            q_taken = jym.tree.gather_actions(q_out_1, train_batch.action)
+            q_taken = jym.tree.batch_sum(q_taken)
+            q_loss = optax.huber_loss(q_taken, target)
+            return jym.tree.mean(q_loss)
+
+        obs, next_obs, reward = (
+            trajectory_batch.observation,
+            trajectory_batch.next_observation,
+            trajectory_batch.reward,
+        )
+        trajectory_batch = replace(
+            trajectory_batch,
+            observation=self.normalizer.normalize_obs(obs),
+            next_observation=self.normalizer.normalize_obs(next_obs),
+            reward=self.normalizer.normalize_reward(reward),
+        )
+
+        # Compute target
+        q_target_output = jax.vmap(self.critic_target)(
+            trajectory_batch.next_observation
+        )
+        q_target_output = jym.tree.batch_sum(
+            jax.tree.map(lambda q: jnp.max(q, axis=-1), q_target_output)
+        )
+        target = (
+            trajectory_batch.reward
+            + ~trajectory_batch.terminated * trainer.gamma * q_target_output
+        )
+
+        grads = __dqn_loss(self.critic, trajectory_batch)
+        updates, optimizer_state = trainer.optimizer.update(grads, self.optimizer_state)
+        new_critic = eqx.apply_updates(self.critic, updates)
+
+        # update target policy
+        new_critic_target = jax.tree.map(
+            lambda x, y: trainer.tau * x + (1 - trainer.tau) * y,
+            self.critic_target,
+            new_critic,
+        )
+
+        return self.replace(
+            critic=new_critic,
+            critic_target=new_critic_target,
+            optimizer_state=optimizer_state,
+        )
 
 
 class DQN(RLAlgorithm):
@@ -188,14 +238,14 @@ class DQN(RLAlgorithm):
             metric = trajectory_batch.info or {}
 
             # Update normalizer with new data from the trajectory
-            agent = self.agent.update_normalizer(trajectory_batch)
+            agent: DQNAgent = self.agent.update_normalizer(trajectory_batch)
 
             # Add new data to buffer & Sample update batch from the buffer
             buffer = buffer.insert(trajectory_batch)
             train_data = buffer.sample(rng)
 
             # Update
-            updated_agent = self._update_agent_state(rng, agent, train_data)
+            updated_agent = agent.update_params(train_data, self)
             self = replace(self, agent=updated_agent)
 
             runner_state = (self, buffer, env_state, last_obs, rng)
@@ -267,59 +317,3 @@ class DQN(RLAlgorithm):
         )
 
         return rollout_state, trajectory_batch
-
-    def _update_agent_state(
-        self, key: PRNGKeyArray, current_agent: DQNAgent, batch: Transition
-    ) -> DQNAgent:
-        def scan_minibatch_update(agent, mini_batch):
-            @eqx.filter_grad
-            def __dqn_loss(params: QValueNetwork, train_batch: Transition):
-                q_out_1 = jax.vmap(params)(train_batch.observation)
-                q_taken = jym.tree.gather_actions(q_out_1, train_batch.action)
-                q_taken = jym.tree.batch_sum(q_taken)
-                q_loss = optax.huber_loss(q_taken, target)
-                return jym.tree.mean(q_loss)
-
-            normalizer = agent.normalizer
-            mini_batch = replace(
-                mini_batch,
-                observation=normalizer.normalize_obs(mini_batch.observation),
-                next_observation=normalizer.normalize_obs(mini_batch.next_observation),
-                reward=normalizer.normalize_reward(mini_batch.reward),
-            )
-
-            # Compute target
-            q_target_output = jax.vmap(agent.critic_target)(mini_batch.next_observation)
-            q_target_output = jym.tree.batch_sum(
-                jax.tree.map(lambda q: jnp.max(q, axis=-1), q_target_output)
-            )
-            target = (
-                mini_batch.reward
-                + ~mini_batch.terminated * self.gamma * q_target_output
-            )
-
-            grads = __dqn_loss(agent.critic, mini_batch)
-            updates, optimizer_state = self.optimizer.update(
-                grads, agent.optimizer_state
-            )
-            new_critic = eqx.apply_updates(agent.critic, updates)
-
-            # update target policy
-            new_critic_target = jax.tree.map(
-                lambda x, y: self.tau * x + (1 - self.tau) * y,
-                agent.critic_target,
-                new_critic,
-            )
-
-            return agent.replace(
-                critic=new_critic,
-                critic_target=new_critic_target,
-                optimizer_state=optimizer_state,
-            ), None
-
-        assert batch.next_observation is not None
-        train_data = batch.make_minibatches(key, self.num_minibatches)
-        updated_agent, _ = train_data.scan(
-            scan_minibatch_update, current_agent, unroll=16
-        )
-        return updated_agent

--- a/src/jaxnasium/algorithms/_dqn.py
+++ b/src/jaxnasium/algorithms/_dqn.py
@@ -93,17 +93,17 @@ class DQNAgent(RLAgent):
             q_loss = optax.huber_loss(q_taken, target)
             return jym.tree.mean(q_loss)
 
-        obs, next_obs, reward = (
-            batch.observation,
-            batch.next_observation,
-            batch.reward,
-        )
-        batch = replace(
-            batch,
-            observation=self.normalizer.normalize_obs(obs),
-            next_observation=self.normalizer.normalize_obs(next_obs),
-            reward=self.normalizer.normalize_reward(reward),
-        )
+        # obs, next_obs, reward = (
+        #     batch.observation,
+        #     batch.next_observation,
+        #     batch.reward,
+        # )
+        # batch = replace(
+        #     batch,
+        #     observation=self.normalizer.normalize_obs(obs),
+        #     next_observation=self.normalizer.normalize_obs(next_obs),
+        #     reward=self.normalizer.normalize_reward(reward),
+        # )
 
         # Compute target
         q_target_output = jax.vmap(self.critic_target)(batch.next_observation)
@@ -214,6 +214,8 @@ class DQN(RLAlgorithm):
             # Add new data to buffer & Sample update batch from the buffer
             buffer = buffer.insert(trajectory_batch)
             train_batch = buffer.sample(rng)
+
+            train_batch = train_batch.normalize(agent.normalizer)
 
             # Update
             updated_agent = agent.update_params(train_batch, self)

--- a/src/jaxnasium/algorithms/_dqn.py
+++ b/src/jaxnasium/algorithms/_dqn.py
@@ -1,7 +1,6 @@
 import logging
 from dataclasses import replace
 from functools import partial
-from typing import Any, Callable
 
 import distrax
 import equinox as eqx
@@ -13,7 +12,7 @@ from jaxtyping import PRNGKeyArray, PyTree
 import jaxnasium as jym
 from jaxnasium import Environment
 from jaxnasium._environment import ORIGINAL_OBSERVATION_KEY
-from jaxnasium.algorithms import RLAlgorithm
+from jaxnasium.algorithms import RLAgent, RLAlgorithm
 from jaxnasium.algorithms.utils import (
     DistraxContainer,
     Normalizer,
@@ -27,11 +26,69 @@ from .networks import QValueNetwork
 logger = logging.getLogger(__name__)
 
 
-class DQNState(eqx.Module):
+class DQNAgent(RLAgent):
     critic: QValueNetwork
     critic_target: QValueNetwork
     optimizer_state: optax.OptState
     normalizer: Normalizer
+
+    def __init__(self, key, env: Environment, trainer: "DQN"):
+        critic = QValueNetwork(
+            key=key,
+            obs_space=env.observation_space,
+            output_space=env.action_space,
+            **trainer.critic_kwargs,
+        )
+        critic_target = jax.tree.map(lambda x: x, critic)
+
+        optimizer_state = trainer.optimizer.init(
+            eqx.filter(critic, eqx.is_inexact_array)
+        )
+
+        normalization_state = Normalizer(
+            obs_space=env.observation_space,
+            normalize_obs=trainer.normalize_observations,
+            normalize_rew=trainer.normalize_rewards,
+            gamma=trainer.gamma,
+            rew_shape=(trainer.num_steps, trainer.num_envs),
+        )
+
+        self.critic = critic
+        self.critic_target = critic_target
+        self.optimizer_state = optimizer_state
+        self.normalizer = normalization_state
+
+    def get_action(
+        self,
+        key: PRNGKeyArray,
+        observation: PyTree,
+        deterministic: bool = False,
+        epsilon: float = 0.0,
+    ):
+        if deterministic:
+            assert epsilon == 0.0, (
+                "Epsilon set to non-zero value for deterministic action"
+            )
+        observation = self.normalizer.normalize_obs(observation)
+        q_values = self.critic(observation)
+        action_dist = DistraxContainer(
+            jax.tree.map(lambda x: distrax.EpsilonGreedy(x, epsilon=epsilon), q_values)
+        )
+        return action_dist.sample(seed=key)
+
+    def get_value(self, observation: PyTree):
+        observation = self.normalizer.normalize_obs(observation)
+        return self.critic(observation)
+
+    def update_normalizer(self, trajectory_batch: Transition):
+        updated_normalizer = self.normalizer.update(trajectory_batch)
+        return self.replace(normalizer=updated_normalizer)
+
+    def normalize_observation(self, observations: PyTree):
+        return self.normalizer.normalize_obs(observations)
+
+    def normalize_reward(self, rewards: PyTree):
+        return self.normalizer.normalize_reward(rewards)
 
 
 class DQN(RLAlgorithm):
@@ -41,26 +98,24 @@ class DQN(RLAlgorithm):
     a replay buffer and epsilon-greedy exploration with optional annealing.
     """
 
-    state: DQNState = eqx.field(default=None)
+    agent: DQNAgent = eqx.field(default=None)
     "State of the DQN algorithm, containing the networks, optimizer state and optional normalization running statistics."
-    optimizer: optax.GradientTransformation = eqx.field(static=True, default=None)
-    "Optimizer used for training the networks."
 
-    learning_rate: float = 2.5e-4
-    anneal_learning_rate: bool | float = eqx.field(static=True, default=False)
+    learning_rate_start: float = 2.5e-4
+    learning_rate_end: float | None = eqx.field(static=True, default=0.0)
     "Whether to anneal the learning rate over time. Set to a float to specify the end value. True means 0.0."
     gamma: float = 0.99
     max_grad_norm: float = 1.0
     update_every: int = eqx.field(static=True, default=int(2e2))
     replay_buffer_size: int = int(1e4)
     batch_size: int = 64
-    epsilon: float = 0.2
-    anneal_epsilon: bool | float = eqx.field(static=True, default=True)
-    "Whether to anneal the exploration rate over time. Set to a float to specify the end value. True means 0.0."
+    epsilon_start: float = 0.2
+    epsilon_end: float | None = eqx.field(static=True, default=0.1)
     tau: float = 0.95
     "Soft update coefficient for target network."
 
     total_timesteps: int = eqx.field(static=True, default=int(1e6))
+    num_minibatches: int = eqx.field(static=True, default=4)
     num_envs: int = eqx.field(static=True, default=4)
     "Number of parallel environments."
 
@@ -70,28 +125,31 @@ class DQN(RLAlgorithm):
     "Whether to normalize rewards via running statistics."
 
     @property
-    def _learning_rate_schedule(self):
-        if self.anneal_learning_rate:
-            end_value = (
-                0.0 if self.anneal_learning_rate is True else self.anneal_learning_rate
-            )
+    def learning_rate(self) -> optax.Schedule:
+        if self.learning_rate_end is not None:
             return optax.linear_schedule(
-                init_value=self.learning_rate,
-                end_value=end_value,
+                init_value=self.learning_rate_start,
+                end_value=self.learning_rate_end,
                 transition_steps=self.num_training_updates,
             )
-        return optax.constant_schedule(self.learning_rate)
+        return optax.constant_schedule(self.learning_rate_start)
 
     @property
-    def _epsilon_schedule(self) -> Callable[..., float]:
-        if self.anneal_epsilon:
-            end_value = 0.0 if self.anneal_epsilon is True else self.anneal_epsilon
+    def epsilon(self) -> optax.Schedule:
+        if self.epsilon_end is not None:
             return optax.linear_schedule(
-                init_value=self.epsilon,
-                end_value=end_value,
+                init_value=self.epsilon_start,
+                end_value=self.epsilon_end,
                 transition_steps=self.num_training_updates,
-            )  # type: ignore
-        return optax.constant_schedule(self.epsilon)  # type: ignore
+            )
+        return optax.constant_schedule(self.epsilon_start)
+
+    @property
+    def optimizer(self):
+        return optax.chain(
+            optax.clip_by_global_norm(self.max_grad_norm),
+            optax.adabelief(learning_rate=self.learning_rate),
+        )
 
     @property
     def num_iterations(self):
@@ -105,46 +163,8 @@ class DQN(RLAlgorithm):
     def num_training_updates(self):
         return self.num_iterations  # * num_epochs
 
-    @staticmethod
-    def get_action(
-        key: PRNGKeyArray,
-        state: DQNState,
-        observation: PyTree,
-        deterministic: bool = False,
-        epsilon: float = 0.0,
-    ):
-        if deterministic:
-            assert epsilon == 0.0, (
-                "Epsilon set to non-zero value for deterministic action"
-            )
-        observation = state.normalizer.normalize_obs(observation)
-        q_values = state.critic(observation)
-        action_dist = DistraxContainer(
-            jax.tree.map(lambda x: distrax.EpsilonGreedy(x, epsilon=epsilon), q_values)
-        )
-        return action_dist.sample(seed=key)
-
     def init_state(self, key: PRNGKeyArray, env: Environment) -> "DQN":
-        if getattr(env, "multi_agent", False) and self.auto_upgrade_multi_agent:
-            self = self.__make_multi_agent__()
-
-        if self.optimizer is None:
-            self = replace(
-                self,
-                optimizer=optax.chain(
-                    optax.clip_by_global_norm(self.max_grad_norm),
-                    optax.adabelief(learning_rate=self._learning_rate_schedule),
-                ),
-            )
-
-        agent_states = self._make_agent_state(
-            key=key,
-            obs_space=env.observation_space,
-            output_space=env.action_space,
-            critic_kwargs=self.critic_kwargs,
-        )
-
-        return replace(self, state=agent_states)
+        return replace(self, agent=DQNAgent(key=key, env=env, trainer=self))
 
     def train(self, key: PRNGKeyArray, env: Environment, **hyperparams) -> "DQN":
         @scan_callback(
@@ -167,20 +187,16 @@ class DQN(RLAlgorithm):
             )
             metric = trajectory_batch.info or {}
 
-            # Post-process the trajectory batch: normalization update (possibly per-agent)
-            updated_state = self._postprocess_rollout(trajectory_batch, self.state)
+            # Update normalizer with new data from the trajectory
+            agent = self.agent.update_normalizer(trajectory_batch)
 
             # Add new data to buffer & Sample update batch from the buffer
             buffer = buffer.insert(trajectory_batch)
             train_data = buffer.sample(rng)
 
             # Update
-            updated_state = self._update_agent_state(
-                rng,
-                updated_state,  # <-- use updated_state w/ updated norm
-                train_data,
-            )
-            self = replace(self, state=updated_state)
+            updated_agent = self._update_agent_state(rng, agent, train_data)
+            self = replace(self, agent=updated_agent)
 
             runner_state = (self, buffer, env_state, last_obs, rng)
             return runner_state, metric
@@ -218,12 +234,9 @@ class DQN(RLAlgorithm):
 
             # select an action
             sample_key = jax.random.split(sample_key, self.num_envs)
-            update_count = jym.tree.get_first(self.state, "count")
-            current_epsilon = self._epsilon_schedule(update_count)
-            get_action = partial(self.get_action, epsilon=current_epsilon)
-            action = jax.vmap(get_action, in_axes=(0, None, 0))(
-                sample_key, self.state, last_obs
-            )
+            update_count = jym.tree.get_first(self.agent, "count")
+            get_action = partial(self.get_action, epsilon=self.epsilon(update_count))
+            action = jax.vmap(get_action, in_axes=(0, 0))(sample_key, last_obs)
 
             # take a step in the environment
             step_key = jax.random.split(step_key, self.num_envs)
@@ -255,100 +268,58 @@ class DQN(RLAlgorithm):
 
         return rollout_state, trajectory_batch
 
-    def _postprocess_rollout(
-        self, trajectory_batch: Transition, current_state: DQNState
-    ) -> DQNState:
-        """
-        1) Returns updated normalization based on the new trajectory batch.
-        """
-        # Update normalization params
-        updated_state = replace(
-            current_state, normalizer=current_state.normalizer.update(trajectory_batch)
-        )
-
-        return updated_state
-
     def _update_agent_state(
-        self, key: PRNGKeyArray, current_state: DQNState, batch: Transition
-    ) -> DQNState:
-        @eqx.filter_grad
-        def __dqn_loss(params: QValueNetwork, train_batch: Transition):
-            q_out_1 = jax.vmap(params)(train_batch.observation)
-            q_taken = jym.tree.gather_actions(q_out_1, train_batch.action)
-            q_taken = jym.tree.batch_sum(q_taken)
-            q_loss = optax.huber_loss(q_taken, target)
-            return jym.tree.mean(q_loss)
+        self, key: PRNGKeyArray, current_agent: DQNAgent, batch: Transition
+    ) -> DQNAgent:
+        def scan_minibatch_update(agent, mini_batch):
+            @eqx.filter_grad
+            def __dqn_loss(params: QValueNetwork, train_batch: Transition):
+                q_out_1 = jax.vmap(params)(train_batch.observation)
+                q_taken = jym.tree.gather_actions(q_out_1, train_batch.action)
+                q_taken = jym.tree.batch_sum(q_taken)
+                q_loss = optax.huber_loss(q_taken, target)
+                return jym.tree.mean(q_loss)
+
+            normalizer = agent.normalizer
+            mini_batch = replace(
+                mini_batch,
+                observation=normalizer.normalize_obs(mini_batch.observation),
+                next_observation=normalizer.normalize_obs(mini_batch.next_observation),
+                reward=normalizer.normalize_reward(mini_batch.reward),
+            )
+
+            # Compute target
+            q_target_output = jax.vmap(agent.critic_target)(mini_batch.next_observation)
+            q_target_output = jym.tree.batch_sum(
+                jax.tree.map(lambda q: jnp.max(q, axis=-1), q_target_output)
+            )
+            target = (
+                mini_batch.reward
+                + ~mini_batch.terminated * self.gamma * q_target_output
+            )
+
+            grads = __dqn_loss(agent.critic, mini_batch)
+            updates, optimizer_state = self.optimizer.update(
+                grads, agent.optimizer_state
+            )
+            new_critic = eqx.apply_updates(agent.critic, updates)
+
+            # update target policy
+            new_critic_target = jax.tree.map(
+                lambda x, y: self.tau * x + (1 - self.tau) * y,
+                agent.critic_target,
+                new_critic,
+            )
+
+            return agent.replace(
+                critic=new_critic,
+                critic_target=new_critic_target,
+                optimizer_state=optimizer_state,
+            ), None
 
         assert batch.next_observation is not None
-
-        normalizer = current_state.normalizer
-        batch = replace(
-            batch,
-            observation=normalizer.normalize_obs(batch.observation),
-            next_observation=normalizer.normalize_obs(batch.next_observation),
-            reward=normalizer.normalize_reward(batch.reward),
+        train_data = batch.make_minibatches(key, self.num_minibatches)
+        updated_agent, _ = train_data.scan(
+            scan_minibatch_update, current_agent, unroll=16
         )
-
-        # Compute target
-        q_target_output = jax.vmap(current_state.critic_target)(batch.next_observation)
-        q_target_output = jym.tree.batch_sum(
-            jax.tree.map(lambda q: jnp.max(q, axis=-1), q_target_output)
-        )
-        target = batch.reward + ~batch.terminated * self.gamma * q_target_output
-
-        grads = __dqn_loss(current_state.critic, batch)
-        updates, optimizer_state = self.optimizer.update(
-            grads, current_state.optimizer_state
-        )
-        new_critic = eqx.apply_updates(current_state.critic, updates)
-
-        # update target policy
-        new_critic_target = jax.tree.map(
-            lambda x, y: self.tau * x + (1 - self.tau) * y,
-            current_state.critic_target,
-            new_critic,
-        )
-
-        updated_state = DQNState(
-            critic=new_critic,
-            critic_target=new_critic_target,
-            optimizer_state=optimizer_state,
-            normalizer=current_state.normalizer,
-        )
-        return updated_state
-
-    def _make_agent_state(
-        self,
-        key: PRNGKeyArray,
-        obs_space: jym.Space,
-        output_space: jym.Space,
-        critic_kwargs: dict[str, Any],
-    ):
-        critic = QValueNetwork(
-            key=key,
-            obs_space=obs_space,
-            output_space=output_space,
-            **critic_kwargs,
-        )
-        critic_target = jax.tree.map(lambda x: x, critic)
-
-        optimizer_state = self.optimizer.init(eqx.filter(critic, eqx.is_inexact_array))
-
-        dummy_obs = jax.tree.map(
-            lambda space: space.sample(jax.random.PRNGKey(0)),
-            obs_space,
-        )
-        normalization_state = Normalizer(
-            dummy_obs,
-            normalize_obs=self.normalize_observations,
-            normalize_rew=self.normalize_rewards,
-            gamma=self.gamma,
-            rew_shape=(self.num_steps, self.num_envs),
-        )
-
-        return DQNState(
-            critic=critic,
-            critic_target=critic_target,
-            optimizer_state=optimizer_state,
-            normalizer=normalization_state,
-        )
+        return updated_agent

--- a/src/jaxnasium/algorithms/_dqn.py
+++ b/src/jaxnasium/algorithms/_dqn.py
@@ -80,11 +80,11 @@ class DQNAgent(RLAgent):
     def normalize_reward(self, rewards: PyTree):
         return self.normalizer.normalize_reward(rewards)
 
-    def update_normalizer(self, trajectory_batch: Transition):
-        updated_normalizer = self.normalizer.update(trajectory_batch)
+    def update_normalizer(self, batch: Transition):
+        updated_normalizer = self.normalizer.update(batch)
         return self.replace(normalizer=updated_normalizer)
 
-    def update_params(self, trajectory_batch: Transition, trainer: "DQN"):
+    def update_params(self, batch: Transition, trainer: "DQN"):
         @eqx.filter_grad
         def __dqn_loss(params: QValueNetwork, train_batch: Transition):
             q_out_1 = jax.vmap(params)(train_batch.observation)
@@ -94,30 +94,25 @@ class DQNAgent(RLAgent):
             return jym.tree.mean(q_loss)
 
         obs, next_obs, reward = (
-            trajectory_batch.observation,
-            trajectory_batch.next_observation,
-            trajectory_batch.reward,
+            batch.observation,
+            batch.next_observation,
+            batch.reward,
         )
-        trajectory_batch = replace(
-            trajectory_batch,
+        batch = replace(
+            batch,
             observation=self.normalizer.normalize_obs(obs),
             next_observation=self.normalizer.normalize_obs(next_obs),
             reward=self.normalizer.normalize_reward(reward),
         )
 
         # Compute target
-        q_target_output = jax.vmap(self.critic_target)(
-            trajectory_batch.next_observation
-        )
+        q_target_output = jax.vmap(self.critic_target)(batch.next_observation)
         q_target_output = jym.tree.batch_sum(
             jax.tree.map(lambda q: jnp.max(q, axis=-1), q_target_output)
         )
-        target = (
-            trajectory_batch.reward
-            + ~trajectory_batch.terminated * trainer.gamma * q_target_output
-        )
+        target = batch.reward + ~batch.terminated * trainer.gamma * q_target_output
 
-        grads = __dqn_loss(self.critic, trajectory_batch)
+        grads = __dqn_loss(self.critic, batch)
         updates, optimizer_state = trainer.optimizer.update(grads, self.optimizer_state)
         new_critic = eqx.apply_updates(self.critic, updates)
 
@@ -218,10 +213,10 @@ class DQN(RLAlgorithm):
 
             # Add new data to buffer & Sample update batch from the buffer
             buffer = buffer.insert(trajectory_batch)
-            train_data = buffer.sample(rng)
+            train_batch = buffer.sample(rng)
 
             # Update
-            updated_agent = agent.update_params(train_data, self)
+            updated_agent = agent.update_params(train_batch, self)
             self = replace(self, agent=updated_agent)
 
             runner_state = (self, buffer, env_state, last_obs, rng)

--- a/src/jaxnasium/algorithms/_dqn.py
+++ b/src/jaxnasium/algorithms/_dqn.py
@@ -51,7 +51,7 @@ class DQNAgent(RLAgent):
             normalize_obs=trainer.normalize_observations,
             normalize_rew=trainer.normalize_rewards,
             gamma=trainer.gamma,
-            rew_shape=(trainer.num_steps, trainer.num_envs),
+            rew_shape=(trainer.rollout_length, trainer.num_envs),
         )
 
     def get_action(
@@ -165,7 +165,7 @@ class DQN(RLAlgorithm):
         return int(self.total_timesteps // self.update_every)
 
     @property
-    def num_steps(self):  # rollout length
+    def rollout_length(self):
         return int(self.update_every // self.num_envs)
 
     @property
@@ -272,7 +272,7 @@ class DQN(RLAlgorithm):
             return rollout_state, transition
 
         if length is None:
-            length = self.num_steps
+            length = self.rollout_length
 
         # Do rollout
         rollout_state, trajectory_batch = jax.lax.scan(

--- a/src/jaxnasium/algorithms/_dqn.py
+++ b/src/jaxnasium/algorithms/_dqn.py
@@ -16,6 +16,7 @@ from jaxnasium.algorithms import RLAgent, RLAlgorithm
 from jaxnasium.algorithms.utils import (
     DistraxContainer,
     Normalizer,
+    Schedule,
     Transition,
     TransitionBuffer,
     scan_callback,
@@ -33,30 +34,25 @@ class DQNAgent(RLAgent):
     normalizer: Normalizer
 
     def __init__(self, key, env: Environment, trainer: "DQN"):
-        critic = QValueNetwork(
+        self.critic = QValueNetwork(
             key=key,
             obs_space=env.observation_space,
             output_space=env.action_space,
             **trainer.critic_kwargs,
         )
-        critic_target = jax.tree.map(lambda x: x, critic)
+        self.critic_target = jax.tree.map(lambda x: x, self.critic)
 
-        optimizer_state = trainer.optimizer.init(
-            eqx.filter(critic, eqx.is_inexact_array)
+        self.optimizer_state = trainer.optimizer.init(
+            eqx.filter(self.critic, eqx.is_inexact_array)
         )
 
-        normalization_state = Normalizer(
+        self.normalizer = Normalizer(
             obs_space=env.observation_space,
             normalize_obs=trainer.normalize_observations,
             normalize_rew=trainer.normalize_rewards,
             gamma=trainer.gamma,
             rew_shape=(trainer.num_steps, trainer.num_envs),
         )
-
-        self.critic = critic
-        self.critic_target = critic_target
-        self.optimizer_state = optimizer_state
-        self.normalizer = normalization_state
 
     def get_action(
         self,
@@ -66,9 +62,7 @@ class DQNAgent(RLAgent):
         epsilon: float = 0.0,
     ):
         if deterministic:
-            assert epsilon == 0.0, (
-                "Epsilon set to non-zero value for deterministic action"
-            )
+            assert epsilon == 0.0, "Non-zero epsilon for deterministic action"
         observation = self.normalizer.normalize_obs(observation)
         q_values = self.critic(observation)
         action_dist = DistraxContainer(
@@ -149,56 +143,38 @@ class DQN(RLAlgorithm):
     """
 
     agent: DQNAgent = eqx.field(default=None)
-    "State of the DQN algorithm, containing the networks, optimizer state and optional normalization running statistics."
+    "State of the DQN agent, containing the networks, optimizer state and optional normalization running statistics."
 
     learning_rate_start: float = 2.5e-4
     learning_rate_end: float | None = eqx.field(static=True, default=0.0)
-    "Whether to anneal the learning rate over time. Set to a float to specify the end value. True means 0.0."
     gamma: float = 0.99
     max_grad_norm: float = 1.0
     update_every: int = eqx.field(static=True, default=int(2e2))
     replay_buffer_size: int = int(1e4)
     batch_size: int = 64
-    epsilon_start: float = 0.2
-    epsilon_end: float | None = eqx.field(static=True, default=0.1)
+    epsilon_start: float = 0.1
+    epsilon_end: float | None = eqx.field(static=True, default=None)
     tau: float = 0.95
-    "Soft update coefficient for target network."
-
     total_timesteps: int = eqx.field(static=True, default=int(1e6))
-    num_minibatches: int = eqx.field(static=True, default=4)
     num_envs: int = eqx.field(static=True, default=4)
-    "Number of parallel environments."
-
     normalize_observations: bool = eqx.field(static=True, default=False)
-    "Whether to normalize observations via running statistics."
     normalize_rewards: bool = eqx.field(static=True, default=False)
-    "Whether to normalize rewards via running statistics."
 
     @property
-    def learning_rate(self) -> optax.Schedule:
-        if self.learning_rate_end is not None:
-            return optax.linear_schedule(
-                init_value=self.learning_rate_start,
-                end_value=self.learning_rate_end,
-                transition_steps=self.num_training_updates,
-            )
-        return optax.constant_schedule(self.learning_rate_start)
+    def epsilon_schedule(self) -> Schedule:
+        return Schedule(self.epsilon_start, self.epsilon_end, self.num_training_updates)
 
     @property
-    def epsilon(self) -> optax.Schedule:
-        if self.epsilon_end is not None:
-            return optax.linear_schedule(
-                init_value=self.epsilon_start,
-                end_value=self.epsilon_end,
-                transition_steps=self.num_training_updates,
-            )
-        return optax.constant_schedule(self.epsilon_start)
+    def learning_rate_schedule(self) -> Schedule:
+        return Schedule(
+            self.learning_rate_start, self.learning_rate_end, self.num_training_updates
+        )
 
     @property
     def optimizer(self):
         return optax.chain(
             optax.clip_by_global_norm(self.max_grad_norm),
-            optax.adabelief(learning_rate=self.learning_rate),
+            optax.adabelief(learning_rate=self.learning_rate_schedule),
         )
 
     @property
@@ -213,7 +189,7 @@ class DQN(RLAlgorithm):
     def num_training_updates(self):
         return self.num_iterations  # * num_epochs
 
-    def init_state(self, key: PRNGKeyArray, env: Environment) -> "DQN":
+    def init_agent(self, key: PRNGKeyArray, env: Environment) -> "DQN":
         return replace(self, agent=DQNAgent(key=key, env=env, trainer=self))
 
     def train(self, key: PRNGKeyArray, env: Environment, **hyperparams) -> "DQN":
@@ -255,7 +231,7 @@ class DQN(RLAlgorithm):
         self = replace(self, **hyperparams)
 
         if not self.is_initialized:
-            self = self.init_state(key, env)
+            self = self.init_agent(key, env)
 
         obsv, env_state = env.reset(jax.random.split(key, self.num_envs))
 
@@ -285,7 +261,9 @@ class DQN(RLAlgorithm):
             # select an action
             sample_key = jax.random.split(sample_key, self.num_envs)
             update_count = jym.tree.get_first(self.agent, "count")
-            get_action = partial(self.get_action, epsilon=self.epsilon(update_count))
+            get_action = partial(
+                self.get_action, epsilon=self.epsilon_schedule(update_count)
+            )
             action = jax.vmap(get_action, in_axes=(0, 0))(sample_key, last_obs)
 
             # take a step in the environment

--- a/src/jaxnasium/algorithms/_ppo.py
+++ b/src/jaxnasium/algorithms/_ppo.py
@@ -13,12 +13,7 @@ import jaxnasium as jym
 from jaxnasium import Environment
 from jaxnasium._environment import ORIGINAL_OBSERVATION_KEY
 from jaxnasium.algorithms import RLAgent, RLAlgorithm
-from jaxnasium.algorithms.utils import (
-    # MultiAgentWrapper,
-    Normalizer,
-    Transition,
-    scan_callback,
-)
+from jaxnasium.algorithms.utils import Normalizer, Schedule, Transition, scan_callback
 
 from .networks import ActorNetwork, ValueNetwork
 
@@ -33,33 +28,28 @@ class PPOAgent(RLAgent):
 
     def __init__(self, key, env: Environment, trainer: "PPO"):
         actor_key, critic_key = jax.random.split(key)
-        actor = ActorNetwork(
+        self.actor = ActorNetwork(
             key=actor_key,
             obs_space=env.observation_space,
             output_space=env.action_space,
             **trainer.actor_kwargs,
         )
-        critic = ValueNetwork(
+        self.critic = ValueNetwork(
             key=critic_key,
             obs_space=env.observation_space,
             **trainer.critic_kwargs,
         )
-        optimizer_state = trainer.optimizer.init(
-            eqx.filter((actor, critic), eqx.is_inexact_array)
+        self.optimizer_state = trainer.optimizer.init(
+            eqx.filter((self.actor, self.critic), eqx.is_inexact_array)
         )
 
-        normalization_state = Normalizer(
+        self.normalizer = Normalizer(
             obs_space=env.observation_space,
             normalize_obs=trainer.normalize_observations,
             normalize_rew=trainer.normalize_rewards,
             gamma=trainer.gamma,
             rew_shape=(trainer.num_steps, trainer.num_envs),
         )
-
-        self.actor = actor
-        self.critic = critic
-        self.optimizer_state = optimizer_state
-        self.normalizer = normalization_state
 
     def get_action(
         self,
@@ -91,6 +81,69 @@ class PPOAgent(RLAgent):
     def normalize_reward(self, rewards: PyTree):
         return self.normalizer.normalize_reward(rewards)
 
+    def update_params(self, trajectory_batch: Transition, trainer: "PPO"):
+        @eqx.filter_grad
+        def __ppo_los_fn(
+            params: Tuple[ActorNetwork, ValueNetwork],
+            train_batch: Transition,
+        ):
+            assert train_batch.advantage is not None
+            assert train_batch.return_ is not None
+            assert train_batch.log_prob is not None
+            assert train_batch.value is not None
+
+            actor, critic = params
+            action_dist = jax.vmap(actor)(train_batch.observation)
+            log_prob = action_dist.log_prob(train_batch.action)
+            entropy = action_dist.entropy()
+            value = jax.vmap(critic)(train_batch.observation)
+            init_log_prob = train_batch.log_prob
+
+            log_prob = jym.tree.batch_sum(log_prob)
+            init_log_prob = jym.tree.batch_sum(init_log_prob)
+            entropy = jym.tree.batch_sum(entropy)
+
+            ratio = jnp.exp(log_prob - init_log_prob)
+            _advantages = (train_batch.advantage - train_batch.advantage.mean()) / (
+                train_batch.advantage.std() + 1e-8
+            )
+            actor_loss1 = _advantages * ratio
+
+            actor_loss2 = (
+                jnp.clip(ratio, 1.0 - trainer.clip_coef, 1.0 + trainer.clip_coef)
+                * _advantages
+            )
+            actor_loss = -jnp.minimum(actor_loss1, actor_loss2).mean()
+
+            # critic loss
+            value_pred_clipped = train_batch.value + (
+                jnp.clip(
+                    value - train_batch.value,
+                    -trainer.clip_coef_vf,
+                    trainer.clip_coef_vf,
+                )
+            )
+            value_losses = jnp.square(value - train_batch.return_)
+            value_losses_clipped = jnp.square(value_pred_clipped - train_batch.return_)
+            value_loss = jnp.maximum(value_losses, value_losses_clipped).mean()
+
+            update_count = jym.tree.get_first(self.optimizer_state, "count")
+            ent_coef = trainer.ent_coef_schedule(update_count)
+
+            # Total loss
+            total_loss = (
+                actor_loss + trainer.vf_coef * value_loss - ent_coef * entropy.mean()
+            )
+            return total_loss  # , (actor_loss, value_loss, entropy)
+
+        actor, critic = self.actor, self.critic
+        grads = __ppo_los_fn((actor, critic), trajectory_batch)
+        updates, optimizer_state = trainer.optimizer.update(grads, self.optimizer_state)
+        new_actor, new_critic = eqx.apply_updates((actor, critic), updates)
+        return self.replace(
+            actor=new_actor, critic=new_critic, optimizer_state=optimizer_state
+        )
+
 
 class PPO(RLAlgorithm):
     """Proximal Policy Optimization (PPO) algorithm implementation."""
@@ -118,30 +171,26 @@ class PPO(RLAlgorithm):
     normalize_rewards: bool = eqx.field(static=True, default=True)
 
     @property
-    def learning_rate(self) -> optax.Schedule:
-        if self.learning_rate_end is not None:
-            return optax.linear_schedule(
-                init_value=self.learning_rate_start,
-                end_value=self.learning_rate_end,
-                transition_steps=self.num_training_updates,
-            )
-        return optax.constant_schedule(self.learning_rate_start)
+    def learning_rate_schedule(self):
+        return Schedule(
+            start=self.learning_rate_start,
+            end=self.learning_rate_end,
+            transition_steps=self.num_training_updates,
+        )
 
     @property
-    def ent_coef(self) -> optax.Schedule:
-        if self.ent_coef_end is not None:
-            return optax.linear_schedule(
-                init_value=self.ent_coef_start,
-                end_value=self.ent_coef_end,
-                transition_steps=self.num_training_updates,
-            )
-        return optax.constant_schedule(self.ent_coef_start)
+    def ent_coef_schedule(self):
+        return Schedule(
+            start=self.ent_coef_start,
+            end=self.ent_coef_end,
+            transition_steps=self.num_training_updates,
+        )
 
     @property
     def optimizer(self):
         return optax.chain(
             optax.clip_by_global_norm(self.max_grad_norm),
-            optax.adabelief(learning_rate=self.learning_rate),
+            optax.adabelief(learning_rate=self.learning_rate_schedule),
         )
 
     @property
@@ -160,7 +209,7 @@ class PPO(RLAlgorithm):
     def num_training_updates(self):
         return self.num_iterations * self.num_epochs
 
-    def init_state(self, key: PRNGKeyArray, env: Environment) -> "PPO":
+    def init_agent(self, key: PRNGKeyArray, env: Environment) -> "PPO":
         return replace(self, agent=PPOAgent(key=key, env=env, trainer=self))
 
     def train(self, key: PRNGKeyArray, env: Environment, **hyperparams) -> "PPO":
@@ -185,8 +234,18 @@ class PPO(RLAlgorithm):
 
             agent = self.agent.update_normalizer(trajectory_batch)
 
-            # Post-process the trajectory batch (GAE, returns, normalization)
-            trajectory_batch = self._postprocess_rollout(trajectory_batch)
+            # Calculate GAE and returns, add to trajectory batch
+            _, (advantages, returns) = (
+                trajectory_batch.scan(  # We can use a normal scan, but this custom scan automatically handles multi-agent scenarios
+                    lambda gae, transition: self._compute_gae_scan(gae, transition),
+                    jnp.zeros(self.num_envs),
+                    reverse=True,
+                    unroll=16,
+                )
+            )
+            trajectory_batch = replace(
+                trajectory_batch, advantage=advantages, return_=returns
+            )
 
             # Update agent
             updated_agent = self._update_agent_state(rng, agent, trajectory_batch)
@@ -199,7 +258,7 @@ class PPO(RLAlgorithm):
         self = replace(self, **hyperparams)
 
         if not self.is_initialized:
-            self = self.init_state(key, env)
+            self = self.init_agent(key, env)
 
         obsv, env_state = env.reset(jax.random.split(key, self.num_envs))
         runner_state = (self, env_state, obsv, key)
@@ -252,129 +311,43 @@ class PPO(RLAlgorithm):
 
         return rollout_state, trajectory_batch
 
-    def _postprocess_rollout(self, trajectory_batch: Transition) -> Transition:
-        """
-        1) Computes GAE and Returns and adds them to the trajectory batch.
-        2) Returns updated normalization based on the new trajectory batch.
-        """
+    def _compute_gae_scan(self, gae, transition: Transition):
+        assert transition.value is not None
+        assert transition.next_value is not None
 
-        def compute_gae_scan(gae, batch: Transition):
-            """
-            Computes the Generalized Advantage Estimation (GAE) for the given batch of transitions.
-            """
-
-            assert batch.value is not None
-            assert batch.next_value is not None
-
-            done = batch.terminated
-            if done.ndim < batch.reward.ndim:
-                # correct for multi-agent envs that do not return done flags per agent
-                done = jnp.expand_dims(done, axis=-1)
-
-            delta = (
-                batch.reward + self.gamma * batch.next_value * (1 - done) - batch.value
-            )
-            gae = delta + self.gamma * self.gae_lambda * (1 - done) * gae
-            return gae, (gae, gae + batch.value)
-
-        trajectory_batch = replace(
-            trajectory_batch,
-            reward=self.agent.normalize_reward(trajectory_batch.reward),
+        done = transition.terminated
+        delta = (
+            transition.reward
+            + self.gamma * transition.next_value * (1 - done)
+            - transition.value
         )
-        assert trajectory_batch.value is not None
-        _, (advantages, returns) = trajectory_batch.scan(
-            compute_gae_scan, jnp.zeros(self.num_envs), reverse=True, unroll=16
-        )
-
-        trajectory_batch = replace(
-            trajectory_batch,
-            advantage=advantages,
-            return_=returns,
-        )
-
-        return trajectory_batch
+        gae = delta + self.gamma * self.gae_lambda * (1 - done) * gae
+        return gae, (gae, gae + transition.value)
 
     def _update_agent_state(
         self, key, current_agent: PPOAgent, train_data: Transition
     ) -> PPOAgent:
-        @eqx.filter_grad
-        def __ppo_los_fn(
-            params: Tuple[ActorNetwork, ValueNetwork],
-            train_batch: Transition,
-        ):
-            assert train_batch.advantage is not None
-            assert train_batch.return_ is not None
-            assert train_batch.log_prob is not None
-            assert train_batch.value is not None
+        """Creates minibatches and performs updates for multiple epochs. Returns the updated agent."""
 
-            actor, critic = params
-            action_dist = jax.vmap(actor)(train_batch.observation)
-            log_prob = action_dist.log_prob(train_batch.action)
-            entropy = action_dist.entropy()
-            value = jax.vmap(critic)(train_batch.observation)
-            init_log_prob = train_batch.log_prob
-
-            log_prob = jym.tree.batch_sum(log_prob)
-            init_log_prob = jym.tree.batch_sum(init_log_prob)
-            entropy = jym.tree.batch_sum(entropy)
-
-            ratio = jnp.exp(log_prob - init_log_prob)
-            _advantages = (train_batch.advantage - train_batch.advantage.mean()) / (
-                train_batch.advantage.std() + 1e-8
-            )
-            actor_loss1 = _advantages * ratio
-
-            actor_loss2 = (
-                jnp.clip(ratio, 1.0 - self.clip_coef, 1.0 + self.clip_coef)
-                * _advantages
-            )
-            actor_loss = -jnp.minimum(actor_loss1, actor_loss2).mean()
-
-            # critic loss
-            value_pred_clipped = train_batch.value + (
-                jnp.clip(
-                    value - train_batch.value,
-                    -self.clip_coef_vf,
-                    self.clip_coef_vf,
-                )
-            )
-            value_losses = jnp.square(value - train_batch.return_)
-            value_losses_clipped = jnp.square(value_pred_clipped - train_batch.return_)
-            value_loss = jnp.maximum(value_losses, value_losses_clipped).mean()
-
-            update_count = jym.tree.get_first(current_agent.optimizer_state, "count")
-            ent_coef = self.ent_coef(update_count)
-
-            # Total loss
-            total_loss = (
-                actor_loss + self.vf_coef * value_loss - ent_coef * entropy.mean()
-            )
-            return total_loss  # , (actor_loss, value_loss, entropy)
-
-        def scan_minibatch_update(current_agent, minibatch):
-            actor, critic = current_agent.actor, current_agent.critic
-            grads = __ppo_los_fn((actor, critic), minibatch)
-            updates, optimizer_state = self.optimizer.update(
-                grads, current_agent.optimizer_state
-            )
-            new_actor, new_critic = eqx.apply_updates((actor, critic), updates)
-            updated_agent = current_agent.replace(
-                actor=new_actor, critic=new_critic, optimizer_state=optimizer_state
-            )
-            return updated_agent, None
-
+        # (num_steps * num_envs, ...) > (batch_size, ...)
         train_data = jax.tree.map(
             lambda x: x.reshape((self.batch_size,) + x.shape[2:]),
             train_data,
         )
-        train_data = replace(
+        train_data = replace(  # Normalization
             train_data,
             observation=current_agent.normalize_observation(train_data.observation),
         )
+        # Make minibatches
         train_data = train_data.make_minibatches(
             key, self.num_minibatches, self.num_epochs
         )
-        updated_agent, _ = train_data.scan(
-            scan_minibatch_update, current_agent, unroll=16
+
+        def scan_update(current_agent, batch):
+            agent = current_agent.update_params(batch, self)
+            return agent, None
+
+        updated_agent, _ = jax.lax.scan(
+            scan_update, current_agent, train_data, unroll=4
         )
         return updated_agent

--- a/src/jaxnasium/algorithms/_ppo.py
+++ b/src/jaxnasium/algorithms/_ppo.py
@@ -331,22 +331,24 @@ class PPO(RLAlgorithm):
     ) -> PPOAgent:
         """Creates minibatches and performs updates for multiple epochs. Returns the updated agent."""
 
+        def scan_epoch_update(current_agent: PPOAgent, key):
+            # Create a fresh set of minibatches and update the agent
+            minibatches = train_batch.make_minibatches(key, self.num_minibatches)
+            return jax.lax.scan(
+                lambda agent, minibatch: (agent.update_params(minibatch, self), None),
+                current_agent,
+                minibatches,
+                unroll=4,
+            )
+
         # (num_steps * num_envs, ...) > (batch_size, ...)
         train_batch = jax.tree.map(
             lambda x: x.reshape((self.batch_size,) + x.shape[2:]),
             trajectory_batch,
         )
 
-        # Make minibatches
-        train_batch = train_batch.make_minibatches(
-            key, self.num_minibatches, self.num_epochs
-        )
-
-        def scan_update(current_agent, batch):
-            agent = current_agent.update_params(batch, self)
-            return agent, None
-
+        update_keys = jax.random.split(key, self.num_epochs)
         updated_agent, _ = jax.lax.scan(
-            scan_update, current_agent, train_batch, unroll=4
+            scan_epoch_update, current_agent, update_keys, unroll=4
         )
         return updated_agent

--- a/src/jaxnasium/algorithms/_ppo.py
+++ b/src/jaxnasium/algorithms/_ppo.py
@@ -234,6 +234,8 @@ class PPO(RLAlgorithm):
 
             agent = self.agent.update_normalizer(trajectory_batch)
 
+            trajectory_batch = trajectory_batch.normalize(agent.normalizer)
+
             # Calculate GAE and returns, add to trajectory batch
             _, (advantages, returns) = (
                 trajectory_batch.scan(  # We can use a normal scan, but this custom scan automatically handles multi-agent scenarios
@@ -334,10 +336,7 @@ class PPO(RLAlgorithm):
             lambda x: x.reshape((self.batch_size,) + x.shape[2:]),
             trajectory_batch,
         )
-        train_batch = replace(  # Normalization
-            train_batch,
-            observation=current_agent.normalize_observation(train_batch.observation),
-        )
+
         # Make minibatches
         train_batch = train_batch.make_minibatches(
             key, self.num_minibatches, self.num_epochs

--- a/src/jaxnasium/algorithms/_ppo.py
+++ b/src/jaxnasium/algorithms/_ppo.py
@@ -71,8 +71,8 @@ class PPOAgent(RLAgent):
         observation = self.normalizer.normalize_obs(observation)
         return self.critic(observation)
 
-    def update_normalizer(self, trajectory_batch: Transition):
-        updated_normalizer = self.normalizer.update(trajectory_batch)
+    def update_normalizer(self, batch: Transition):
+        updated_normalizer = self.normalizer.update(batch)
         return self.replace(normalizer=updated_normalizer)
 
     def normalize_observation(self, observations: PyTree):
@@ -81,7 +81,7 @@ class PPOAgent(RLAgent):
     def normalize_reward(self, rewards: PyTree):
         return self.normalizer.normalize_reward(rewards)
 
-    def update_params(self, trajectory_batch: Transition, trainer: "PPO"):
+    def update_params(self, batch: Transition, trainer: "PPO"):
         @eqx.filter_grad
         def __ppo_los_fn(
             params: Tuple[ActorNetwork, ValueNetwork],
@@ -137,7 +137,7 @@ class PPOAgent(RLAgent):
             return total_loss  # , (actor_loss, value_loss, entropy)
 
         actor, critic = self.actor, self.critic
-        grads = __ppo_los_fn((actor, critic), trajectory_batch)
+        grads = __ppo_los_fn((actor, critic), batch)
         updates, optimizer_state = trainer.optimizer.update(grads, self.optimizer_state)
         new_actor, new_critic = eqx.apply_updates((actor, critic), updates)
         return self.replace(
@@ -325,21 +325,21 @@ class PPO(RLAlgorithm):
         return gae, (gae, gae + transition.value)
 
     def _update_agent_state(
-        self, key, current_agent: PPOAgent, train_data: Transition
+        self, key, current_agent: PPOAgent, trajectory_batch: Transition
     ) -> PPOAgent:
         """Creates minibatches and performs updates for multiple epochs. Returns the updated agent."""
 
         # (num_steps * num_envs, ...) > (batch_size, ...)
-        train_data = jax.tree.map(
+        train_batch = jax.tree.map(
             lambda x: x.reshape((self.batch_size,) + x.shape[2:]),
-            train_data,
+            trajectory_batch,
         )
-        train_data = replace(  # Normalization
-            train_data,
-            observation=current_agent.normalize_observation(train_data.observation),
+        train_batch = replace(  # Normalization
+            train_batch,
+            observation=current_agent.normalize_observation(train_batch.observation),
         )
         # Make minibatches
-        train_data = train_data.make_minibatches(
+        train_batch = train_batch.make_minibatches(
             key, self.num_minibatches, self.num_epochs
         )
 
@@ -348,6 +348,6 @@ class PPO(RLAlgorithm):
             return agent, None
 
         updated_agent, _ = jax.lax.scan(
-            scan_update, current_agent, train_data, unroll=4
+            scan_update, current_agent, train_batch, unroll=4
         )
         return updated_agent

--- a/src/jaxnasium/algorithms/_ppo.py
+++ b/src/jaxnasium/algorithms/_ppo.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import replace
 from functools import partial
-from typing import Any, Tuple
+from typing import Tuple
 
 import equinox as eqx
 import jax
@@ -12,36 +12,115 @@ from jaxtyping import Array, PRNGKeyArray, PyTree
 import jaxnasium as jym
 from jaxnasium import Environment
 from jaxnasium._environment import ORIGINAL_OBSERVATION_KEY
-from jaxnasium.algorithms import RLAlgorithm
-from jaxnasium.algorithms.utils import Normalizer, Transition, scan_callback
+from jaxnasium.algorithms import RLAgent, RLAlgorithm
+from jaxnasium.algorithms.utils import (
+    # MultiAgentWrapper,
+    Normalizer,
+    Transition,
+    scan_callback,
+)
 
 from .networks import ActorNetwork, ValueNetwork
 
 logger = logging.getLogger(__name__)
 
 
-class PPOState(eqx.Module):
+class PPOAgent(RLAgent):
     actor: ActorNetwork
     critic: ValueNetwork
     optimizer_state: optax.OptState
     normalizer: Normalizer
 
+    def __init__(self, key, env: Environment, trainer: "PPO"):
+        actor_key, critic_key = jax.random.split(key)
+        actor_kwargs = trainer.actor_kwargs
+        critic_kwargs = trainer.critic_kwargs
+        normalize_observations = trainer.normalize_observations
+        normalize_rewards = trainer.normalize_rewards
+        gamma = trainer.gamma
+        num_steps = trainer.num_steps
+        num_envs = trainer.num_envs
+        optimizer = trainer.optimizer
+        actor = ActorNetwork(
+            key=actor_key,
+            obs_space=env.observation_space,
+            output_space=env.action_space,
+            **actor_kwargs,
+        )
+        critic = ValueNetwork(
+            key=critic_key,
+            obs_space=env.observation_space,
+            **critic_kwargs,
+        )
+        optimizer_state = optimizer.init(
+            eqx.filter((actor, critic), eqx.is_inexact_array)
+        )
+
+        dummy_obs = jax.tree.map(
+            lambda space: space.sample(jax.random.PRNGKey(0)), env.observation_space
+        )
+        normalization_state = Normalizer(
+            dummy_obs,
+            normalize_obs=normalize_observations,
+            normalize_rew=normalize_rewards,
+            gamma=gamma,
+            rew_shape=(num_steps, num_envs),
+        )
+
+        self.actor = actor
+        self.critic = critic
+        self.optimizer_state = optimizer_state
+        self.normalizer = normalization_state
+
+    def get_action(
+        self,
+        key: PRNGKeyArray,
+        observation: PyTree,
+        deterministic: bool = False,
+        get_log_prob: bool = False,
+    ) -> Array | Tuple[Array, Array]:
+        observation = self.normalizer.normalize_obs(observation)
+        action_dist = self.actor(observation)
+        if deterministic:
+            assert not get_log_prob, "Cannot get log prob in deterministic mode"
+            return action_dist.mode()
+        if get_log_prob:
+            return action_dist.sample_and_log_prob(seed=key)  # type: ignore
+        return action_dist.sample(seed=key)
+
+    def get_value(self, observation: PyTree):
+        observation = self.normalizer.normalize_obs(observation)
+        return self.critic(observation)
+
+    def update_normalizer(self, trajectory_batch: Transition):
+        updated_normalizer = self.normalizer.update(trajectory_batch)
+        return self.replace(normalizer=updated_normalizer)
+
+    def normalize_observation(self, observations: PyTree):
+        return self.normalizer.normalize_obs(observations)
+
+    def normalize_reward(self, rewards: PyTree):
+        return self.normalizer.normalize_reward(rewards)
+
+    def replace(self, **updates):
+        keys, values = zip(*updates.items())
+        return eqx.tree_at(lambda c: [c.__dict__[key] for key in keys], self, values)
+
 
 class PPO(RLAlgorithm):
     """Proximal Policy Optimization (PPO) algorithm implementation."""
 
-    state: PPOState = eqx.field(default=None)
-    optimizer: optax.GradientTransformation = eqx.field(static=True, default=None)
+    agent: PPOAgent = eqx.field(default=None)
 
-    learning_rate: float = 2.5e-3
-    anneal_learning_rate: bool | float = eqx.field(static=True, default=True)
+    learning_rate_start: float = 2.5e-3
+    learning_rate_end: float | None = eqx.field(static=True, default=0.0)
+    ent_coef_start: float = 0.01
+    ent_coef_end: float | None = eqx.field(static=True, default=None)
     gamma: float = 0.99
     gae_lambda: float = 0.95
     max_grad_norm: float = 0.5
     clip_coef: float = 0.2
     clip_coef_vf: float = 10.0
-    ent_coef: float = 0.01
-    anneal_ent_coef: bool | float = eqx.field(static=True, default=False)
     vf_coef: float = 0.25
 
     total_timesteps: int = eqx.field(static=True, default=int(1e6))
@@ -54,28 +133,31 @@ class PPO(RLAlgorithm):
     normalize_rewards: bool = eqx.field(static=True, default=True)
 
     @property
-    def _learning_rate_schedule(self):
-        if self.anneal_learning_rate:
-            end_value = (
-                0.0 if self.anneal_learning_rate is True else self.anneal_learning_rate
-            )
+    def learning_rate(self) -> optax.Schedule:
+        if self.learning_rate_end is not None:
             return optax.linear_schedule(
-                init_value=self.learning_rate,
-                end_value=end_value,
+                init_value=self.learning_rate_start,
+                end_value=self.learning_rate_end,
                 transition_steps=self.num_training_updates,
             )
-        return optax.constant_schedule(self.learning_rate)
+        return optax.constant_schedule(self.learning_rate_start)
 
     @property
-    def _ent_coef_schedule(self):
-        if self.anneal_ent_coef:
-            end_value = 0.0 if self.anneal_ent_coef is True else self.anneal_ent_coef
+    def ent_coef(self) -> optax.Schedule:
+        if self.ent_coef_end is not None:
             return optax.linear_schedule(
-                init_value=self.ent_coef,
-                end_value=end_value,
+                init_value=self.ent_coef_start,
+                end_value=self.ent_coef_end,
                 transition_steps=self.num_training_updates,
             )
-        return optax.constant_schedule(self.ent_coef)
+        return optax.constant_schedule(self.ent_coef_start)
+
+    @property
+    def optimizer(self):
+        return optax.chain(
+            optax.clip_by_global_norm(self.max_grad_norm),
+            optax.adabelief(learning_rate=self.learning_rate),
+        )
 
     @property
     def minibatch_size(self):
@@ -93,50 +175,8 @@ class PPO(RLAlgorithm):
     def num_training_updates(self):
         return self.num_iterations * self.num_epochs
 
-    @staticmethod
-    def get_action(
-        key: PRNGKeyArray,
-        state: PPOState,
-        observation: PyTree,
-        deterministic: bool = False,
-        get_log_prob: bool = False,
-    ) -> Array | Tuple[Array, Array]:
-        observation = state.normalizer.normalize_obs(observation)
-        action_dist = state.actor(observation)
-        if deterministic:
-            assert not get_log_prob, "Cannot get log prob in deterministic mode"
-            return action_dist.mode()
-        if get_log_prob:
-            return action_dist.sample_and_log_prob(seed=key)  # type: ignore
-        return action_dist.sample(seed=key)
-
-    @staticmethod
-    def get_value(state: PPOState, observation: PyTree):
-        observation = state.normalizer.normalize_obs(observation)
-        return state.critic(observation)
-
     def init_state(self, key: PRNGKeyArray, env: Environment) -> "PPO":
-        if getattr(env, "multi_agent", False) and self.auto_upgrade_multi_agent:
-            self = self.__make_multi_agent__()
-
-        if self.optimizer is None:
-            self = replace(
-                self,
-                optimizer=optax.chain(
-                    optax.clip_by_global_norm(self.max_grad_norm),
-                    optax.adabelief(learning_rate=self._learning_rate_schedule),
-                ),
-            )
-
-        agent_states = self._make_agent_state(
-            key=key,
-            obs_space=env.observation_space,
-            output_space=env.action_space,
-            actor_kwargs=self.actor_kwargs,
-            critic_kwargs=self.critic_kwargs,
-        )
-
-        return replace(self, state=agent_states)
+        return replace(self, agent=PPOAgent(key=key, env=env, trainer=self))
 
     def train(self, key: PRNGKeyArray, env: Environment, **hyperparams) -> "PPO":
         @scan_callback(
@@ -158,18 +198,14 @@ class PPO(RLAlgorithm):
             )
             metric = trajectory_batch.info or {}
 
+            agent = self.agent.update_normalizer(trajectory_batch)
+
             # Post-process the trajectory batch (GAE, returns, normalization)
-            trajectory_batch, updated_state = self._postprocess_rollout(
-                trajectory_batch, self.state
-            )
+            trajectory_batch = self._postprocess_rollout(trajectory_batch)
 
             # Update agent
-            updated_state = self._update_agent_state(
-                rng,
-                updated_state,  # <-- Use updated state with updated normalizer
-                trajectory_batch,
-            )
-            self = replace(self, state=updated_state)
+            updated_agent = self._update_agent_state(rng, agent, trajectory_batch)
+            self = replace(self, agent=updated_agent)
 
             runner_state = (self, env_state, last_obs, rng)
             return runner_state, metric
@@ -195,23 +231,17 @@ class PPO(RLAlgorithm):
 
             # select an action
             sample_key = jax.random.split(sample_key, self.num_envs)
-            get_action_and_log_prob = partial(self.get_action, get_log_prob=True)
-            action, log_prob = jax.vmap(get_action_and_log_prob, in_axes=(0, None, 0))(
-                sample_key, self.state, last_obs
-            )
+            get_action_and_log_prob = partial(self.agent.get_action, get_log_prob=True)
+
+            action, log_prob = jax.vmap(get_action_and_log_prob)(sample_key, last_obs)
 
             # take a step in the environment
             step_key = jax.random.split(step_key, self.num_envs)
             (obsv, reward, terminated, truncated, info), env_state = env.step(
                 step_key, env_state, action
             )
-            value = jax.vmap(self.get_value, in_axes=(None, 0))(self.state, last_obs)
-            next_value = jax.vmap(self.get_value, in_axes=(None, 0))(
-                self.state, info[ORIGINAL_OBSERVATION_KEY]
-            )
-
-            # TODO ?
-            # gamma = info.get("ENV_GAMMA", self.gamma)
+            value = jax.vmap(self.agent.get_value)(last_obs)
+            next_value = jax.vmap(self.agent.get_value)(info[ORIGINAL_OBSERVATION_KEY])
 
             # Build a single transition. Jax.lax.scan will build the batch
             # returning num_steps transitions.
@@ -237,9 +267,7 @@ class PPO(RLAlgorithm):
 
         return rollout_state, trajectory_batch
 
-    def _postprocess_rollout(
-        self, trajectory_batch: Transition, current_state: PPOState
-    ) -> Tuple[Transition, PPOState]:
+    def _postprocess_rollout(self, trajectory_batch: Transition) -> Transition:
         """
         1) Computes GAE and Returns and adds them to the trajectory batch.
         2) Returns updated normalization based on the new trajectory batch.
@@ -253,23 +281,24 @@ class PPO(RLAlgorithm):
             assert batch.value is not None
             assert batch.next_value is not None
 
-            reward = current_state.normalizer.normalize_reward(batch.reward)
             done = batch.terminated
-            if done.ndim < reward.ndim:
+            if done.ndim < batch.reward.ndim:
                 # correct for multi-agent envs that do not return done flags per agent
                 done = jnp.expand_dims(done, axis=-1)
 
-            delta = reward + self.gamma * batch.next_value * (1 - done) - batch.value
+            delta = (
+                batch.reward + self.gamma * batch.next_value * (1 - done) - batch.value
+            )
             gae = delta + self.gamma * self.gae_lambda * (1 - done) * gae
             return gae, (gae, gae + batch.value)
 
-        assert trajectory_batch.value is not None
-        _, (advantages, returns) = jax.lax.scan(
-            compute_gae_scan,
-            optax.tree.zeros_like(trajectory_batch.value[-1]),
+        trajectory_batch = replace(
             trajectory_batch,
-            reverse=True,
-            unroll=16,
+            reward=self.agent.normalize_reward(trajectory_batch.reward),
+        )
+        assert trajectory_batch.value is not None
+        _, (advantages, returns) = trajectory_batch.scan(
+            compute_gae_scan, jnp.zeros(self.num_envs), reverse=True, unroll=16
         )
 
         trajectory_batch = replace(
@@ -278,16 +307,11 @@ class PPO(RLAlgorithm):
             return_=returns,
         )
 
-        # Update normalization params
-        updated_state = replace(
-            current_state, normalizer=current_state.normalizer.update(trajectory_batch)
-        )
-
-        return trajectory_batch, updated_state
+        return trajectory_batch
 
     def _update_agent_state(
-        self, key, current_state: PPOState, train_data: Transition
-    ) -> PPOState:
+        self, key, current_agent: PPOAgent, train_data: Transition
+    ) -> PPOAgent:
         @eqx.filter_grad
         def __ppo_los_fn(
             params: Tuple[ActorNetwork, ValueNetwork],
@@ -296,13 +320,13 @@ class PPO(RLAlgorithm):
             assert train_batch.advantage is not None
             assert train_batch.return_ is not None
             assert train_batch.log_prob is not None
+            assert train_batch.value is not None
 
             actor, critic = params
-            norm_obs = current_state.normalizer.normalize_obs(train_batch.observation)
-            action_dist = jax.vmap(actor)(norm_obs)
+            action_dist = jax.vmap(actor)(train_batch.observation)
             log_prob = action_dist.log_prob(train_batch.action)
             entropy = action_dist.entropy()
-            value = jax.vmap(critic)(norm_obs)
+            value = jax.vmap(critic)(train_batch.observation)
             init_log_prob = train_batch.log_prob
 
             log_prob = jym.tree.batch_sum(log_prob)
@@ -333,8 +357,8 @@ class PPO(RLAlgorithm):
             value_losses_clipped = jnp.square(value_pred_clipped - train_batch.return_)
             value_loss = jnp.maximum(value_losses, value_losses_clipped).mean()
 
-            update_count = jym.tree.get_first(current_state.optimizer_state, "count")
-            ent_coef = self._ent_coef_schedule(update_count)
+            update_count = jym.tree.get_first(current_agent.optimizer_state, "count")
+            ent_coef = self.ent_coef(update_count)
 
             # Total loss
             total_loss = (
@@ -342,76 +366,30 @@ class PPO(RLAlgorithm):
             )
             return total_loss  # , (actor_loss, value_loss, entropy)
 
-        def scan_minibatch_update(current_state, minibatch):
-            actor, critic = current_state.actor, current_state.critic
+        def scan_minibatch_update(current_agent, minibatch):
+            actor, critic = current_agent.actor, current_agent.critic
             grads = __ppo_los_fn((actor, critic), minibatch)
             updates, optimizer_state = self.optimizer.update(
-                grads, current_state.optimizer_state
+                grads, current_agent.optimizer_state
             )
             new_actor, new_critic = eqx.apply_updates((actor, critic), updates)
-
-            updated_state = PPOState(
-                actor=new_actor,
-                critic=new_critic,
-                optimizer_state=optimizer_state,
-                normalizer=current_state.normalizer,  # already updated
+            updated_agent = current_agent.replace(
+                actor=new_actor, critic=new_critic, optimizer_state=optimizer_state
             )
-            return updated_state, None
+            return updated_agent, None
 
-        def scan_epoch_update(current_state, key):
-            minibatches = train_data.make_minibatches(
-                key, self.num_minibatches, n_batch_axis=2
-            )
-            updated_state, _ = jax.lax.scan(
-                scan_minibatch_update, current_state, minibatches
-            )
-            return updated_state, None
-
-        update_keys = jax.random.split(key, self.num_epochs)
-        updated_state, _ = jax.lax.scan(
-            scan_epoch_update, current_state, update_keys, unroll=16
+        train_data = jax.tree.map(
+            lambda x: x.reshape((self.batch_size,) + x.shape[2:]),
+            train_data,
         )
-        return updated_state
-
-    def _make_agent_state(
-        self,
-        key: PRNGKeyArray,
-        obs_space: jym.Space,
-        output_space: jym.Space,
-        actor_kwargs: dict[str, Any],
-        critic_kwargs: dict[str, Any],
-    ):
-        actor_key, critic_key = jax.random.split(key)
-        actor = ActorNetwork(
-            key=actor_key,
-            obs_space=obs_space,
-            output_space=output_space,
-            **actor_kwargs,
+        train_data = replace(
+            train_data,
+            observation=current_agent.normalize_observation(train_data.observation),
         )
-        critic = ValueNetwork(
-            key=critic_key,
-            obs_space=obs_space,
-            **critic_kwargs,
+        train_data = train_data.make_minibatches(
+            key, self.num_minibatches, self.num_epochs
         )
-        optimizer_state = self.optimizer.init(
-            eqx.filter((actor, critic), eqx.is_inexact_array)
+        updated_agent, _ = train_data.scan(
+            scan_minibatch_update, current_agent, unroll=16
         )
-
-        dummy_obs = jax.tree.map(
-            lambda space: space.sample(jax.random.PRNGKey(0)),
-            obs_space,
-        )
-        normalization_state = Normalizer(
-            dummy_obs,
-            normalize_obs=self.normalize_observations,
-            normalize_rew=self.normalize_rewards,
-            gamma=self.gamma,
-            rew_shape=(self.num_steps, self.num_envs),
-        )
-
-        return PPOState(
-            actor=actor,
-            critic=critic,
-            optimizer_state=optimizer_state,
-            normalizer=normalization_state,
-        )
+        return updated_agent

--- a/src/jaxnasium/algorithms/_ppo.py
+++ b/src/jaxnasium/algorithms/_ppo.py
@@ -33,38 +33,27 @@ class PPOAgent(RLAgent):
 
     def __init__(self, key, env: Environment, trainer: "PPO"):
         actor_key, critic_key = jax.random.split(key)
-        actor_kwargs = trainer.actor_kwargs
-        critic_kwargs = trainer.critic_kwargs
-        normalize_observations = trainer.normalize_observations
-        normalize_rewards = trainer.normalize_rewards
-        gamma = trainer.gamma
-        num_steps = trainer.num_steps
-        num_envs = trainer.num_envs
-        optimizer = trainer.optimizer
         actor = ActorNetwork(
             key=actor_key,
             obs_space=env.observation_space,
             output_space=env.action_space,
-            **actor_kwargs,
+            **trainer.actor_kwargs,
         )
         critic = ValueNetwork(
             key=critic_key,
             obs_space=env.observation_space,
-            **critic_kwargs,
+            **trainer.critic_kwargs,
         )
-        optimizer_state = optimizer.init(
+        optimizer_state = trainer.optimizer.init(
             eqx.filter((actor, critic), eqx.is_inexact_array)
         )
 
-        dummy_obs = jax.tree.map(
-            lambda space: space.sample(jax.random.PRNGKey(0)), env.observation_space
-        )
         normalization_state = Normalizer(
-            dummy_obs,
-            normalize_obs=normalize_observations,
-            normalize_rew=normalize_rewards,
-            gamma=gamma,
-            rew_shape=(num_steps, num_envs),
+            obs_space=env.observation_space,
+            normalize_obs=trainer.normalize_observations,
+            normalize_rew=trainer.normalize_rewards,
+            gamma=trainer.gamma,
+            rew_shape=(trainer.num_steps, trainer.num_envs),
         )
 
         self.actor = actor
@@ -101,10 +90,6 @@ class PPOAgent(RLAgent):
 
     def normalize_reward(self, rewards: PyTree):
         return self.normalizer.normalize_reward(rewards)
-
-    def replace(self, **updates):
-        keys, values = zip(*updates.items())
-        return eqx.tree_at(lambda c: [c.__dict__[key] for key in keys], self, values)
 
 
 class PPO(RLAlgorithm):

--- a/src/jaxnasium/algorithms/_pqn.py
+++ b/src/jaxnasium/algorithms/_pqn.py
@@ -278,15 +278,20 @@ class PQN(RLAlgorithm):
         self, key, current_agent: PQNAgent, trajectory_batch: Transition
     ) -> PQNAgent:
         def scan_epoch_update(current_agent: PQNAgent, key):
-            minibatches = trajectory_batch.make_minibatches(
-                key, self.num_minibatches, n_batch_axis=2
+            # Create a fresh set of minibatches and update the agent
+            minibatches = train_batch.make_minibatches(key, self.num_minibatches)
+            return jax.lax.scan(
+                lambda agent, minibatch: (agent.update_params(minibatch, self), None),
+                current_agent,
+                minibatches,
+                unroll=4,
             )
 
-            def do_update(current_state, minibatch):
-                return current_state.update_params(minibatch, self), None
-
-            updated_agent, _ = jax.lax.scan(do_update, current_agent, minibatches)
-            return updated_agent, None
+        # (num_steps * num_envs, ...) > (batch_size, ...)
+        train_batch = jax.tree.map(
+            lambda x: x.reshape((self.batch_size,) + x.shape[2:]),
+            trajectory_batch,
+        )
 
         update_keys = jax.random.split(key, self.num_epochs)
         updated_agent, _ = jax.lax.scan(

--- a/src/jaxnasium/algorithms/_pqn.py
+++ b/src/jaxnasium/algorithms/_pqn.py
@@ -77,11 +77,11 @@ class PQNAgent(RLAgent):
     def normalize_reward(self, rewards: PyTree):
         return self.normalizer.normalize_reward(rewards)
 
-    def update_normalizer(self, trajectory_batch: Transition):
-        updated_normalizer = self.normalizer.update(trajectory_batch)
+    def update_normalizer(self, batch: Transition):
+        updated_normalizer = self.normalizer.update(batch)
         return self.replace(normalizer=updated_normalizer)
 
-    def update_params(self, trajectory_batch: Transition, trainer: "PQN"):
+    def update_params(self, batch: Transition, trainer: "PQN"):
         @eqx.filter_grad
         def __dqn_loss(params: QValueNetwork, train_batch: Transition):
             q_out_1 = jax.vmap(params)(train_batch.observation)
@@ -90,7 +90,7 @@ class PQNAgent(RLAgent):
             q_loss = optax.huber_loss(q_taken, train_batch.return_)
             return jym.tree.mean(q_loss)
 
-        grads = __dqn_loss(self.critic, trajectory_batch)
+        grads = __dqn_loss(self.critic, batch)
         updates, optimizer_state = trainer.optimizer.update(grads, self.optimizer_state)
         new_critic = eqx.apply_updates(self.critic, updates)
 
@@ -273,10 +273,10 @@ class PQN(RLAlgorithm):
         return return_this_step, return_this_step
 
     def _update_agent_state(
-        self, key, current_agent: PQNAgent, train_data: Transition
+        self, key, current_agent: PQNAgent, trajectory_batch: Transition
     ) -> PQNAgent:
         def scan_epoch_update(current_agent: PQNAgent, key):
-            minibatches = train_data.make_minibatches(
+            minibatches = train_batch.make_minibatches(
                 key, self.num_minibatches, n_batch_axis=2
             )
 
@@ -286,9 +286,11 @@ class PQN(RLAlgorithm):
             updated_agent, _ = jax.lax.scan(do_update, current_agent, minibatches)
             return updated_agent, None
 
-        train_data = replace(
-            train_data,
-            observation=current_agent.normalizer.normalize_obs(train_data.observation),
+        train_batch = replace(
+            trajectory_batch,
+            observation=current_agent.normalizer.normalize_obs(
+                trajectory_batch.observation
+            ),
         )
         update_keys = jax.random.split(key, self.num_epochs)
         updated_agent, _ = jax.lax.scan(

--- a/src/jaxnasium/algorithms/_pqn.py
+++ b/src/jaxnasium/algorithms/_pqn.py
@@ -184,6 +184,8 @@ class PQN(RLAlgorithm):
             # Update normalizer with new data from the trajectory
             agent: PQNAgent = self.agent.update_normalizer(trajectory_batch)
 
+            trajectory_batch = trajectory_batch.normalize(agent.normalizer)
+
             # Calculate Qlambda returns, add to trajectory batch
             _, returns = (
                 trajectory_batch.scan(  # We can use a normal scan, but this custom scan automatically handles multi-agent scenarios
@@ -276,7 +278,7 @@ class PQN(RLAlgorithm):
         self, key, current_agent: PQNAgent, trajectory_batch: Transition
     ) -> PQNAgent:
         def scan_epoch_update(current_agent: PQNAgent, key):
-            minibatches = train_batch.make_minibatches(
+            minibatches = trajectory_batch.make_minibatches(
                 key, self.num_minibatches, n_batch_axis=2
             )
 
@@ -286,12 +288,6 @@ class PQN(RLAlgorithm):
             updated_agent, _ = jax.lax.scan(do_update, current_agent, minibatches)
             return updated_agent, None
 
-        train_batch = replace(
-            trajectory_batch,
-            observation=current_agent.normalizer.normalize_obs(
-                trajectory_batch.observation
-            ),
-        )
         update_keys = jax.random.split(key, self.num_epochs)
         updated_agent, _ = jax.lax.scan(
             scan_epoch_update, current_agent, update_keys, unroll=4

--- a/src/jaxnasium/algorithms/_pqn.py
+++ b/src/jaxnasium/algorithms/_pqn.py
@@ -1,7 +1,6 @@
 import logging
 from dataclasses import replace
 from functools import partial
-from typing import Any, Callable
 
 import distrax
 import equinox as eqx
@@ -13,10 +12,11 @@ from jaxtyping import PRNGKeyArray, PyTree
 import jaxnasium as jym
 from jaxnasium import Environment
 from jaxnasium._environment import ORIGINAL_OBSERVATION_KEY
-from jaxnasium.algorithms import RLAlgorithm
+from jaxnasium.algorithms import RLAgent, RLAlgorithm
 from jaxnasium.algorithms.utils import (
     DistraxContainer,
     Normalizer,
+    Schedule,
     Transition,
     scan_callback,
 )
@@ -26,24 +26,88 @@ from .networks import QValueNetwork
 logger = logging.getLogger(__name__)
 
 
-class PQNState(eqx.Module):
+class PQNAgent(RLAgent):
     critic: QValueNetwork
     optimizer_state: optax.OptState
     normalizer: Normalizer
+
+    def __init__(self, key, env: Environment, trainer: "PQN"):
+        self.critic = QValueNetwork(
+            key=key,
+            obs_space=env.observation_space,
+            output_space=env.action_space,
+            **trainer.critic_kwargs,
+        )
+
+        self.optimizer_state = trainer.optimizer.init(
+            eqx.filter(self.critic, eqx.is_inexact_array)
+        )
+
+        self.normalizer = Normalizer(
+            obs_space=env.observation_space,
+            normalize_obs=trainer.normalize_observations,
+            normalize_rew=trainer.normalize_rewards,
+            gamma=trainer.gamma,
+            rew_shape=(trainer.num_steps, trainer.num_envs),
+        )
+
+    def get_action(
+        self,
+        key: PRNGKeyArray,
+        observation: PyTree,
+        deterministic: bool = False,
+        epsilon: float = 0.0,
+    ):
+        if deterministic:
+            assert epsilon == 0.0, "Non-zero epsilon for deterministic action"
+        observation = self.normalizer.normalize_obs(observation)
+        q_values = self.critic(observation)
+        action_dist = DistraxContainer(
+            jax.tree.map(lambda x: distrax.EpsilonGreedy(x, epsilon=epsilon), q_values)
+        )
+        return action_dist.sample(seed=key)
+
+    def get_value(self, observation: PyTree):
+        observation = self.normalizer.normalize_obs(observation)
+        return self.critic(observation)
+
+    def normalize_observation(self, observations: PyTree):
+        return self.normalizer.normalize_obs(observations)
+
+    def normalize_reward(self, rewards: PyTree):
+        return self.normalizer.normalize_reward(rewards)
+
+    def update_normalizer(self, trajectory_batch: Transition):
+        updated_normalizer = self.normalizer.update(trajectory_batch)
+        return self.replace(normalizer=updated_normalizer)
+
+    def update_params(self, trajectory_batch: Transition, trainer: "PQN"):
+        @eqx.filter_grad
+        def __dqn_loss(params: QValueNetwork, train_batch: Transition):
+            q_out_1 = jax.vmap(params)(train_batch.observation)
+            q_taken = jym.tree.gather_actions(q_out_1, train_batch.action)
+            q_taken = jym.tree.batch_sum(q_taken)
+            q_loss = optax.huber_loss(q_taken, train_batch.return_)
+            return jym.tree.mean(q_loss)
+
+        grads = __dqn_loss(self.critic, trajectory_batch)
+        updates, optimizer_state = trainer.optimizer.update(grads, self.optimizer_state)
+        new_critic = eqx.apply_updates(self.critic, updates)
+
+        return self.replace(critic=new_critic, optimizer_state=optimizer_state)
 
 
 class PQN(RLAlgorithm):
     """Parallel Q-Network (PQN) algorithm implementation."""
 
-    state: PQNState = eqx.field(default=None)
-    optimizer: optax.GradientTransformation = eqx.field(static=True, default=None)
+    agent: PQNAgent = eqx.field(default=None)
 
-    learning_rate: float = 2.5e-4
-    anneal_learning_rate: bool | float = eqx.field(static=True, default=True)
+    learning_rate_start: float = 2.5e-4
+    learning_rate_end: float | None = eqx.field(static=True, default=0.0)
+    epsilon_start: float = 0.1
+    epsilon_end: float | None = eqx.field(static=True, default=None)
     gamma: float = 0.99
     max_grad_norm: float = 10.0
-    epsilon: float = 0.25
-    anneal_epsilon: bool | float = eqx.field(static=True, default=True)
     q_lambda: float = 0.65
 
     total_timesteps: int = eqx.field(static=True, default=int(1e6))
@@ -56,28 +120,27 @@ class PQN(RLAlgorithm):
     normalize_rewards: bool = eqx.field(static=True, default=False)
 
     @property
-    def _learning_rate_schedule(self):
-        if self.anneal_learning_rate:
-            end_value = (
-                0.0 if self.anneal_learning_rate is True else self.anneal_learning_rate
-            )
-            return optax.linear_schedule(
-                init_value=self.learning_rate,
-                end_value=end_value,
-                transition_steps=self.num_training_updates,
-            )
-        return optax.constant_schedule(self.learning_rate)
+    def learning_rate_schedule(self):
+        return Schedule(
+            start=self.learning_rate_start,
+            end=self.learning_rate_end,
+            transition_steps=self.num_training_updates,
+        )
 
     @property
-    def _epsilon_schedule(self) -> Callable[..., float]:
-        if self.anneal_epsilon:
-            end_value = 0.0 if self.anneal_epsilon is True else self.anneal_epsilon
-            return optax.linear_schedule(
-                init_value=self.epsilon,
-                end_value=end_value,
-                transition_steps=self.num_training_updates,
-            )  # type: ignore
-        return optax.constant_schedule(self.epsilon)  # type: ignore
+    def epsilon_schedule(self):
+        return Schedule(
+            start=self.epsilon_start,
+            end=self.epsilon_end,
+            transition_steps=self.num_training_updates,
+        )
+
+    @property
+    def optimizer(self):
+        return optax.chain(
+            optax.clip_by_global_norm(self.max_grad_norm),
+            optax.adabelief(learning_rate=self.learning_rate_schedule),
+        )
 
     @property
     def minibatch_size(self):
@@ -95,46 +158,8 @@ class PQN(RLAlgorithm):
     def num_training_updates(self):
         return self.num_iterations * self.num_epochs * self.num_minibatches
 
-    @staticmethod
-    def get_action(
-        key: PRNGKeyArray,
-        state: PQNState,
-        observation: PyTree,
-        deterministic: bool = False,
-        epsilon: float = 0.0,
-    ):
-        if deterministic:
-            assert epsilon == 0.0, (
-                "Epsilon set to non-zero value for deterministic action"
-            )
-        observation = state.normalizer.normalize_obs(observation)
-        q_values = state.critic(observation)
-        action_dist = DistraxContainer(
-            jax.tree.map(lambda x: distrax.EpsilonGreedy(x, epsilon=epsilon), q_values)
-        )
-        return action_dist.sample(seed=key)
-
-    def init_state(self, key: PRNGKeyArray, env: Environment) -> "PQN":
-        if getattr(env, "multi_agent", False) and self.auto_upgrade_multi_agent:
-            self = self.__make_multi_agent__()
-
-        if self.optimizer is None:
-            self = replace(
-                self,
-                optimizer=optax.chain(
-                    optax.clip_by_global_norm(self.max_grad_norm),
-                    optax.adabelief(learning_rate=self.learning_rate),
-                ),
-            )
-
-        agent_states = self._make_agent_state(
-            key=key,
-            obs_space=env.observation_space,
-            output_space=env.action_space,
-            critic_kwargs=self.critic_kwargs,
-        )
-
-        return replace(self, state=agent_states)
+    def init_agent(self, key: PRNGKeyArray, env: Environment) -> "PQN":
+        return replace(self, agent=PQNAgent(key=key, env=env, trainer=self))
 
     def train(self, key: PRNGKeyArray, env: Environment, **hyperparams) -> "PQN":
         @scan_callback(
@@ -152,22 +177,27 @@ class PQN(RLAlgorithm):
             self: PQN = runner_state[0]
             rollout_state = runner_state[1:]
             (env_state, last_obs, rng), trajectory_batch = self._collect_rollout(
-                rollout_state, env, train_iter
+                rollout_state, env
             )
             metric = trajectory_batch.info or {}
 
-            # Post-process the trajectory batch (GAE, returns, normalization)
-            trajectory_batch, updated_state = self._postprocess_rollout(
-                trajectory_batch, self.state
+            # Update normalizer with new data from the trajectory
+            agent: PQNAgent = self.agent.update_normalizer(trajectory_batch)
+
+            # Calculate Qlambda returns, add to trajectory batch
+            _, returns = (
+                trajectory_batch.scan(  # We can use a normal scan, but this custom scan automatically handles multi-agent scenarios
+                    lambda re, transition: self._compute_q_lambda_scan(re, transition),
+                    jnp.zeros(self.num_envs),
+                    reverse=True,
+                    unroll=16,
+                )
             )
+            trajectory_batch = replace(trajectory_batch, return_=returns)
 
             # Update agent
-            updated_state = self._update_agent_state(
-                rng,
-                updated_state,  # <-- Use updated_state w/ updated normalizer
-                trajectory_batch,
-            )
-            self = replace(self, state=updated_state)
+            updated_agent = self._update_agent_state(rng, agent, trajectory_batch)
+            self = replace(self, agent=updated_agent)
 
             runner_state = (self, env_state, last_obs, rng)
             return runner_state, metric
@@ -176,7 +206,7 @@ class PQN(RLAlgorithm):
         self = replace(self, **hyperparams)
 
         if not self.is_initialized:
-            self = self.init_state(key, env)
+            self = self.init_agent(key, env)
 
         obsv, env_state = env.reset(jax.random.split(key, self.num_envs))
         runner_state = (self, env_state, obsv, key)
@@ -186,24 +216,26 @@ class PQN(RLAlgorithm):
         updated_self = runner_state[0]
         return updated_self
 
-    def _collect_rollout(self, rollout_state, env: Environment, train_iter: int = 0):
+    def _collect_rollout(self, rollout_state, env: Environment):
         def env_step(rollout_state, _):
             env_state, last_obs, rng = rollout_state
             rng, sample_key, step_key = jax.random.split(rng, 3)
 
             # select an action
             sample_key = jax.random.split(sample_key, self.num_envs)
-            update_count = jym.tree.get_first(self.state, "count")
-            current_epsilon = self._epsilon_schedule(update_count)
+            update_count = jym.tree.get_first(self.agent, "count")
+            current_epsilon = self.epsilon_schedule(update_count)
             get_action = partial(self.get_action, epsilon=current_epsilon)
-            action = jax.vmap(get_action, in_axes=(0, None, 0))(
-                sample_key, self.state, last_obs
-            )
+            action = jax.vmap(get_action)(sample_key, last_obs)
 
             # take a step in the environment
             step_key = jax.random.split(step_key, self.num_envs)
             (obsv, reward, terminated, truncated, info), env_state = env.step(
                 step_key, env_state, action
+            )
+
+            next_q_value = jax.vmap(self.agent.get_value)(
+                info[ORIGINAL_OBSERVATION_KEY]
             )
 
             # Build a single transition. jax.lax.scan builds a batch of transitions.
@@ -213,8 +245,9 @@ class PQN(RLAlgorithm):
                 reward=reward,
                 terminated=terminated,
                 truncated=truncated,
-                next_observation=info[ORIGINAL_OBSERVATION_KEY],
+                # next_observation=info[ORIGINAL_OBSERVATION_KEY],
                 info=info,
+                next_value=next_q_value,
             )
 
             rollout_state = (env_state, obsv, rng)
@@ -227,128 +260,38 @@ class PQN(RLAlgorithm):
 
         return rollout_state, trajectory_batch
 
-    def _postprocess_rollout(
-        self, trajectory_batch: Transition, current_state: PQNState
-    ) -> tuple[Transition, PQNState]:
-        """Returns updated normalization based on the new trajectory batch
-        and returns the Qlambda targets.
-        """
-
-        def compute_q_lambda_scan(next_return, batch: Transition):
-            next_obs = batch.next_observation
-            norm_next_obs = current_state.normalizer.normalize_obs(next_obs)
-            norm_reward = current_state.normalizer.normalize_reward(batch.reward)
-            next_q_values = jax.vmap(current_state.critic)(norm_next_obs)
-            next_q_values = jax.tree.map(lambda q: jnp.max(q, axis=-1), next_q_values)
-            next_q_values = jym.tree.batch_sum(next_q_values)
-
-            done = batch.terminated
-            if done.ndim < norm_reward.ndim:
-                # correct for multi-agent envs that do not return done flags per agent
-                done = jnp.expand_dims(done, axis=-1)
-
-            return_this_step = norm_reward + (1 - done) * self.gamma * (
-                self.q_lambda * next_return + (1 - self.q_lambda) * next_q_values
-            )
-            return return_this_step, return_this_step
-
-        assert trajectory_batch.next_observation is not None
-        last_obs = current_state.normalizer.normalize_obs(
-            jax.tree.map(lambda x: x[-1], trajectory_batch.next_observation)
+    def _compute_q_lambda_scan(self, next_return, transition: Transition):
+        next_q_values = jax.tree.map(
+            lambda q: jnp.max(q, axis=-1), transition.next_value
         )
-        last_q_values = jax.vmap(current_state.critic)(last_obs)
-        last_q_values = jax.tree.map(lambda q: jnp.max(q, axis=-1), last_q_values)
-        last_q_values = jym.tree.batch_sum(last_q_values)
-        _, returns = jax.lax.scan(
-            compute_q_lambda_scan,
-            last_q_values.astype(jnp.float32),
-            trajectory_batch,
-            reverse=True,
-            unroll=16,
+        next_q_values = jym.tree.batch_sum(next_q_values)
+
+        done = transition.terminated
+        return_this_step = transition.reward + (1 - done) * self.gamma * (
+            self.q_lambda * next_return + (1 - self.q_lambda) * next_q_values
         )
-
-        trajectory_batch = replace(trajectory_batch, return_=returns)
-
-        # Update normalization params
-        updated_state = replace(
-            current_state, normalizer=current_state.normalizer.update(trajectory_batch)
-        )
-
-        return trajectory_batch, updated_state
+        return return_this_step, return_this_step
 
     def _update_agent_state(
-        self, key, current_state: PQNState, train_data: Transition
-    ) -> PQNState:
-        def scan_minibatch_update(current_state: PQNState, minibatch: Transition):
-            @eqx.filter_grad
-            def __dqn_loss(params: QValueNetwork, train_batch: Transition):
-                q_out_1 = jax.vmap(params)(train_batch.observation)
-                q_taken = jym.tree.gather_actions(q_out_1, train_batch.action)
-                q_taken = jym.tree.batch_sum(q_taken)
-                q_loss = optax.huber_loss(q_taken, minibatch.return_)
-                return jym.tree.mean(q_loss)
-
-            grads = __dqn_loss(current_state.critic, minibatch)
-            updates, optimizer_state = self.optimizer.update(
-                grads, current_state.optimizer_state
-            )
-            new_critic = eqx.apply_updates(current_state.critic, updates)
-
-            updated_state = PQNState(
-                critic=new_critic,
-                optimizer_state=optimizer_state,
-                normalizer=current_state.normalizer,  # already updated
-            )
-            return updated_state, None
-
-        def scan_epoch_update(current_state, key):
+        self, key, current_agent: PQNAgent, train_data: Transition
+    ) -> PQNAgent:
+        def scan_epoch_update(current_agent: PQNAgent, key):
             minibatches = train_data.make_minibatches(
                 key, self.num_minibatches, n_batch_axis=2
             )
-            updated_state, _ = jax.lax.scan(
-                scan_minibatch_update, current_state, minibatches
-            )
-            return updated_state, None
+
+            def do_update(current_state, minibatch):
+                return current_state.update_params(minibatch, self), None
+
+            updated_agent, _ = jax.lax.scan(do_update, current_agent, minibatches)
+            return updated_agent, None
 
         train_data = replace(
             train_data,
-            observation=current_state.normalizer.normalize_obs(train_data.observation),
+            observation=current_agent.normalizer.normalize_obs(train_data.observation),
         )
         update_keys = jax.random.split(key, self.num_epochs)
-        updated_state, _ = jax.lax.scan(
-            scan_epoch_update, current_state, update_keys, unroll=16
+        updated_agent, _ = jax.lax.scan(
+            scan_epoch_update, current_agent, update_keys, unroll=4
         )
-        return updated_state
-
-    def _make_agent_state(
-        self,
-        key: PRNGKeyArray,
-        obs_space: jym.Space,
-        output_space: jym.Space,
-        critic_kwargs: dict[str, Any],
-    ):
-        critic = QValueNetwork(
-            key=key,
-            obs_space=obs_space,
-            output_space=output_space,
-            **critic_kwargs,
-        )
-        optimizer_state = self.optimizer.init(eqx.filter(critic, eqx.is_inexact_array))
-
-        dummy_obs = jax.tree.map(
-            lambda space: space.sample(jax.random.PRNGKey(0)),
-            obs_space,
-        )
-        normalization_state = Normalizer(
-            dummy_obs,
-            normalize_obs=self.normalize_observations,
-            normalize_rew=self.normalize_rewards,
-            gamma=self.gamma,
-            rew_shape=(self.num_steps, self.num_envs),
-        )
-
-        return PQNState(
-            critic=critic,
-            optimizer_state=optimizer_state,
-            normalizer=normalization_state,
-        )
+        return updated_agent

--- a/src/jaxnasium/algorithms/_sac.py
+++ b/src/jaxnasium/algorithms/_sac.py
@@ -342,6 +342,8 @@ class SAC(RLAlgorithm):
             buffer = buffer.insert(trajectory_batch)
             train_batch = buffer.sample(rng)
 
+            train_batch = train_batch.normalize(agent.normalizer)
+
             # Update
             updated_agent = self._update_agent_state(rng, agent, train_batch)
 
@@ -419,15 +421,6 @@ class SAC(RLAlgorithm):
     def _update_agent_state(
         self, key: PRNGKeyArray, current_state: SACAgent, train_batch: Transition
     ) -> SACAgent:
-        # Normalize all used inputs, if normalization is disabled, these are no-ops
-        normalizer = current_state.normalizer
-        train_batch = replace(
-            train_batch,
-            observation=normalizer.normalize_obs(train_batch.observation),
-            next_observation=normalizer.normalize_obs(train_batch.next_observation),
-            reward=normalizer.normalize_reward(train_batch.reward),
-        )
-
         def scan_critics_epoch_update(current_agent: SACAgent, key):
             minibatches = train_batch.make_minibatches(
                 key, self.critics_num_minibatches

--- a/src/jaxnasium/algorithms/_sac.py
+++ b/src/jaxnasium/algorithms/_sac.py
@@ -419,68 +419,58 @@ class SAC(RLAlgorithm):
         return rollout_state, trajectory_batch
 
     def _update_agent_state(
-        self, key: PRNGKeyArray, current_state: SACAgent, train_batch: Transition
+        self, key: PRNGKeyArray, current_agent: SACAgent, train_batch: Transition
     ) -> SACAgent:
-        def scan_critics_epoch_update(current_agent: SACAgent, key):
-            minibatches = train_batch.make_minibatches(
-                key, self.critics_num_minibatches
-            )
+        def update_network(key, agent, batch, update_fn, num_epochs, num_minibatches):
+            def scan_epoch_update(current_agent, key):
+                # Create a fresh set of minibatches and update the agent
+                shuffle_key, update_key = jax.random.split(key)
+                minibatches = batch.make_minibatches(shuffle_key, num_minibatches)
 
-            def do_update(key_and_current_agent, minibatch):
-                key, current_agent = key_and_current_agent
-                key, next_key = jax.random.split(key, 2)
-                updated_agent = current_agent.update_critics_params(
-                    key, minibatch, self
+                def scan_minibatch_update(agent, minibatch_and_key):
+                    minibatch, key = minibatch_and_key
+                    return update_fn(agent, key, minibatch), None
+
+                update_keys = jax.random.split(update_key, num_minibatches)
+                return jax.lax.scan(
+                    scan_minibatch_update,
+                    current_agent,
+                    (minibatches, update_keys),
+                    unroll=4,
                 )
-                return (next_key, updated_agent), None
 
-            (_, updated_agent), _ = jax.lax.scan(
-                do_update, (key, current_agent), minibatches
-            )
-            return updated_agent, None
+            update_keys = jax.random.split(key, num_epochs)
+            return jax.lax.scan(scan_epoch_update, agent, update_keys, unroll=4)
 
-        update_keys = jax.random.split(key, self.critics_num_epochs)
-        updated_agent, _ = jax.lax.scan(
-            scan_critics_epoch_update, current_state, update_keys
+        update_critic_fn = lambda a, k, m: a.update_critics_params(k, m, self)
+        update_actor_fn = lambda a, k, m: a.update_actor_params(k, m, self)
+        update_alpha_fn = lambda a, k, m: a.update_alpha_params(k, m, self)
+
+        agent, _ = update_network(
+            key,
+            current_agent,
+            train_batch,
+            update_critic_fn,
+            self.critics_num_epochs,
+            self.critics_num_minibatches,
         )
 
-        def scan_actor_epoch_update(current_agent: SACAgent, key):
-            minibatches = train_batch.make_minibatches(key, self.actor_num_minibatches)
-
-            def do_update(key_and_current_agent, minibatch):
-                key, current_agent = key_and_current_agent
-                key, next_key = jax.random.split(key, 2)
-                updated_agent = current_agent.update_actor_params(key, minibatch, self)
-                return (next_key, updated_agent), None
-
-            (_, updated_agent), _ = jax.lax.scan(
-                do_update, (key, current_agent), minibatches
-            )
-            return updated_agent, None
-
-        update_keys = jax.random.split(key, self.actor_num_epochs)
-        updated_agent, _ = jax.lax.scan(
-            scan_actor_epoch_update, updated_agent, update_keys
+        agent, _ = update_network(
+            key,
+            agent,
+            train_batch,
+            update_actor_fn,
+            self.actor_num_epochs,
+            self.actor_num_minibatches,
         )
 
-        def scan_alpha_epoch_update(current_agent: SACAgent, key):
-            minibatches = train_batch.make_minibatches(key, self.alpha_num_minibatches)
+        agent, _ = update_network(
+            key,
+            agent,
+            train_batch,
+            update_alpha_fn,
+            self.alpha_num_epochs,
+            self.alpha_num_minibatches,
+        )
 
-            def do_update(key_and_current_agent, minibatch):
-                key, current_agent = key_and_current_agent
-                key, next_key = jax.random.split(key, 2)
-                updated_agent = current_agent.update_alpha_params(key, minibatch, self)
-                return (next_key, updated_agent), None
-
-            (_, updated_agent), _ = jax.lax.scan(
-                do_update, (key, current_agent), minibatches
-            )
-            return updated_agent, None
-
-        if self.learn_alpha:
-            update_keys = jax.random.split(key, self.alpha_num_epochs)
-            updated_agent, _ = jax.lax.scan(
-                scan_alpha_epoch_update, updated_agent, update_keys
-            )
-
-        return updated_agent
+        return agent

--- a/src/jaxnasium/algorithms/_sac.py
+++ b/src/jaxnasium/algorithms/_sac.py
@@ -109,7 +109,7 @@ class SACAgent(RLAgent):
 
     def _compute_soft_target(self, action_dist, q, action_log_prob):
         if isinstance(action_dist, distrax.Categorical):
-            action_log_prob = jnp.log(action_dist.probs + 1e-8)
+            action_log_prob = jax.nn.log_softmax(action_dist.logits)
         min_q = q.min(axis=0)
         target = min_q - self.alpha() * action_log_prob
         if isinstance(action_dist, distrax.Categorical):
@@ -180,7 +180,7 @@ class SACAgent(RLAgent):
                 target_entropy = trainer.target_entropy
                 if isinstance(action_dist, distrax.Categorical):
                     action_probs = action_dist.probs
-                    log_probs = jnp.log(action_probs + 1e-8)
+                    log_probs = jax.nn.log_softmax(action_dist.logits)
                     if target_entropy is None:
                         action_dim = jnp.prod(jnp.array(log_probs.shape[1:]))
                         target_entropy = (

--- a/src/jaxnasium/algorithms/_sac.py
+++ b/src/jaxnasium/algorithms/_sac.py
@@ -97,6 +97,16 @@ class SACAgent(RLAgent):
             return action_dist.mode()
         return action_dist.sample(seed=key)
 
+    def update_normalizer(self, batch: Transition):
+        updated_normalizer = self.normalizer.update(batch)
+        return self.replace(normalizer=updated_normalizer)
+
+    def normalize_observation(self, observations: PyTree):
+        return self.normalizer.normalize_obs(observations)
+
+    def normalize_reward(self, rewards: PyTree):
+        return self.normalizer.normalize_reward(rewards)
+
     def _compute_soft_target(self, action_dist, q, action_log_prob):
         if isinstance(action_dist, distrax.Categorical):
             action_log_prob = jnp.log(action_dist.probs + 1e-8)
@@ -107,19 +117,19 @@ class SACAgent(RLAgent):
             return weighted_target
         return target
 
-    def update_actor_params(self, key, trajectory_batch: Transition, trainer: "SAC"):
+    def update_actor_params(self, key, batch: Transition, trainer: "SAC"):
         @eqx.filter_grad
-        def __sac_actor_loss(params, batch: Transition):
-            action_dist = jax.vmap(params)(batch.observation)
+        def __sac_actor_loss(params, train_batch: Transition):
+            action_dist = jax.vmap(params)(train_batch.observation)
             action, log_prob = action_dist.sample_and_log_prob(seed=key)
-            q = ensambled_vmap(self.critics, batch.observation, action)
+            q = ensambled_vmap(self.critics, train_batch.observation, action)
             target = jym.tree.map_distribution(
                 self._compute_soft_target, action_dist, q, log_prob
             )
             target = jym.tree.batch_sum(target)
             return -jym.tree.mean(target)
 
-        actor_grads = __sac_actor_loss(self.actor, trajectory_batch)
+        actor_grads = __sac_actor_loss(self.actor, batch)
 
         updates, optimizer_state = trainer.optimizer["actor"].update(
             actor_grads, self.optimizer_state["actor"]
@@ -128,31 +138,24 @@ class SACAgent(RLAgent):
         optimizer_state = {**self.optimizer_state, "actor": optimizer_state}
         return self.replace(actor=new_actor, optimizer_state=optimizer_state)
 
-    def update_critics_params(self, key, trajectory_batch: Transition, trainer: "SAC"):
+    def update_critics_params(self, key, batch: Transition, trainer: "SAC"):
         @eqx.filter_grad
-        def __sac_qnet_loss(params, batch: Transition):
-            q_out = jax.vmap(params)(batch.observation, batch.action)
-            q_taken = jym.tree.gather_actions(q_out, batch.action)
+        def __sac_qnet_loss(params, train_batch: Transition):
+            q_out = jax.vmap(params)(train_batch.observation, train_batch.action)
+            q_taken = jym.tree.gather_actions(q_out, train_batch.action)
             q_taken = jym.tree.batch_sum(q_taken)
             q_loss = optax.losses.huber_loss(q_taken, q_target)
             return jym.tree.mean(q_loss)
 
-        action_dist = jax.vmap(self.actor)(trajectory_batch.next_observation)
+        action_dist = jax.vmap(self.actor)(batch.next_observation)
         action, log_prob = action_dist.sample_and_log_prob(seed=key)
-        q = ensambled_vmap(
-            self.critics_target, trajectory_batch.next_observation, action
-        )
+        q = ensambled_vmap(self.critics_target, batch.next_observation, action)
         target = jym.tree.map_distribution(
             self._compute_soft_target, action_dist, q, log_prob
         )
         target = jym.tree.batch_sum(target)
-        q_target = (
-            trajectory_batch.reward
-            + (1.0 - trajectory_batch.terminated) * trainer.gamma * target
-        )
-        grads = jax.vmap(__sac_qnet_loss, in_axes=(0, None))(
-            self.critics, trajectory_batch
-        )
+        q_target = batch.reward + (1.0 - batch.terminated) * trainer.gamma * target
+        grads = jax.vmap(__sac_qnet_loss, in_axes=(0, None))(self.critics, batch)
         updates, optimizer_state = trainer.optimizer["critics"].update(
             grads, self.optimizer_state["critics"]
         )
@@ -170,9 +173,9 @@ class SACAgent(RLAgent):
             optimizer_state=optimizer_state,
         )
 
-    def update_alpha_params(self, key, trajectory_batch: Transition, trainer: "SAC"):
+    def update_alpha_params(self, key, batch: Transition, trainer: "SAC"):
         @eqx.filter_grad
-        def __sac_alpha_loss(params: Alpha, batch: Transition):
+        def __sac_alpha_loss(params: Alpha, train_batch: Transition):
             def _compute_alpha_signal(action_dist):
                 target_entropy = trainer.target_entropy
                 if isinstance(action_dist, distrax.Categorical):
@@ -187,7 +190,7 @@ class SACAgent(RLAgent):
                 else:  # Continuous action space
                     _, log_probs = action_dist.sample_and_log_prob(seed=key)
                     if target_entropy is None:
-                        action_dim = jnp.prod(jnp.array(batch.action.shape[1:]))
+                        action_dim = jnp.prod(jnp.array(train_batch.action.shape[1:]))
                         target_entropy = target_entropy_scale * -action_dim
                     return log_probs + target_entropy
 
@@ -197,8 +200,8 @@ class SACAgent(RLAgent):
 
         count = jym.tree.get_first(self.optimizer_state["alpha"], "count")
         target_entropy_scale = trainer.target_entropy_scale_schedule(count)
-        action_dist = jax.vmap(self.actor)(trajectory_batch.observation)
-        alpha_grads = __sac_alpha_loss(self.alpha, trajectory_batch)
+        action_dist = jax.vmap(self.actor)(batch.observation)
+        alpha_grads = __sac_alpha_loss(self.alpha, batch)
 
         updates, optimizer_state = trainer.optimizer["alpha"].update(
             alpha_grads, self.optimizer_state["alpha"]
@@ -206,16 +209,6 @@ class SACAgent(RLAgent):
         new_alpha = eqx.apply_updates(self.alpha, updates)
         optimizer_state = {**self.optimizer_state, "alpha": optimizer_state}
         return self.replace(alpha=new_alpha, optimizer_state=optimizer_state)
-
-    def update_normalizer(self, trajectory_batch: Transition):
-        updated_normalizer = self.normalizer.update(trajectory_batch)
-        return self.replace(normalizer=updated_normalizer)
-
-    def normalize_observation(self, observations: PyTree):
-        return self.normalizer.normalize_obs(observations)
-
-    def normalize_reward(self, rewards: PyTree):
-        return self.normalizer.normalize_reward(rewards)
 
 
 class SAC(RLAlgorithm):

--- a/src/jaxnasium/algorithms/_sac.py
+++ b/src/jaxnasium/algorithms/_sac.py
@@ -7,14 +7,15 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import optax
-from jaxtyping import Array, PRNGKeyArray
+from jaxtyping import Array, PRNGKeyArray, PyTree
 
 import jaxnasium as jym
 from jaxnasium import Environment
 from jaxnasium._environment import ORIGINAL_OBSERVATION_KEY
-from jaxnasium.algorithms import RLAlgorithm
+from jaxnasium.algorithms import RLAgent, RLAlgorithm
 from jaxnasium.algorithms.utils import (
     Normalizer,
+    Schedule,
     Transition,
     TransitionBuffer,
     scan_callback,
@@ -23,6 +24,11 @@ from jaxnasium.algorithms.utils import (
 from .networks import ActorNetwork, QValueNetwork
 
 logger = logging.getLogger(__name__)
+
+
+@eqx.filter_vmap(in_axes=(eqx.if_array(0), None, None))
+def ensambled_vmap(model, *x):
+    return jax.vmap(model)(*x)
 
 
 class Alpha(eqx.Module):
@@ -35,28 +41,182 @@ class Alpha(eqx.Module):
         return jnp.exp(self.ent_coef)
 
 
-class SACState(eqx.Module):
+class SACAgent(RLAgent):
     actor: ActorNetwork
-    critic1: QValueNetwork
-    critic2: QValueNetwork
-    critic1_target: QValueNetwork
-    critic2_target: QValueNetwork
+    critics: QValueNetwork
+    critics_target: QValueNetwork
     alpha: Alpha
-    optimizer_state_actor: optax.OptState
-    optimizer_state_critics: optax.OptState
+    optimizer_state: dict[str, optax.OptState]
     normalizer: Normalizer
 
-
-def _create_schedule(anneal_param, init_value, num_training_updates):
-    """Create a linear or constant schedule based on annealing parameter."""
-    if anneal_param:
-        end_value = 0.0 if anneal_param is True else anneal_param
-        return optax.linear_schedule(
-            init_value=init_value,
-            end_value=end_value,
-            transition_steps=num_training_updates,
+    def __init__(self, key, env: Environment, trainer: "SAC"):
+        actor_key, critics_key = jax.random.split(key, 2)
+        self.actor = ActorNetwork(
+            key=actor_key,
+            obs_space=env.observation_space,
+            output_space=env.action_space,
+            **trainer.actor_kwargs,
         )
-    return optax.constant_schedule(init_value)
+        ensamble_critics_keys = jax.random.split(critics_key, 2)  # 2 critics
+        self.critics = jax.vmap(
+            lambda key: QValueNetwork(
+                key=key,
+                obs_space=env.observation_space,
+                output_space=env.action_space,
+                **trainer.critic_kwargs,
+            )
+        )(ensamble_critics_keys)
+
+        self.critics_target = jax.tree.map(lambda x: x, self.critics)
+        self.alpha = Alpha(jnp.log(trainer.init_alpha))
+
+        self.optimizer_state = jym.tree.map_one_level(
+            lambda opt, params: opt.init(eqx.filter(params, eqx.is_inexact_array)),
+            trainer.optimizer,
+            {
+                "actor": self.actor,
+                "critics": self.critics,
+                "alpha": self.alpha,
+            },
+        )
+
+        self.normalizer = Normalizer(
+            obs_space=env.observation_space,
+            normalize_obs=trainer.normalize_observations,
+            normalize_rew=trainer.normalize_rewards,
+            gamma=trainer.gamma,
+            rew_shape=(trainer.num_steps, trainer.num_envs),
+        )
+
+    def get_action(
+        self, key: PRNGKeyArray, observation, deterministic: bool = False
+    ) -> Array:
+        observation = self.normalizer.normalize_obs(observation)
+        action_dist = self.actor(observation)
+        if deterministic:
+            return action_dist.mode()
+        return action_dist.sample(seed=key)
+
+    def _compute_soft_target(self, action_dist, action_log_probs, q):
+        def discrete_soft_target(action_probs, q):
+            action_log_prob = jnp.log(action_probs + 1e-8)
+            min_q = q.min(axis=0)
+            target = min_q - self.alpha() * action_log_prob
+            weighted_target = (action_probs * target).sum(axis=-1)
+            return weighted_target
+
+        def continuous_soft_target(action_log_probs, q):
+            min_q = q.min(axis=0)
+            return min_q - self.alpha() * action_log_probs
+
+        if isinstance(action_dist, distrax.Categorical):
+            return discrete_soft_target(action_dist.probs, q)
+        return continuous_soft_target(action_log_probs, q)
+
+    def update_actor_params(self, key, trajectory_batch: Transition, trainer: "SAC"):
+        @eqx.filter_grad
+        def __sac_actor_loss(params, batch: Transition):
+            action_dist = jax.vmap(params)(batch.observation)
+            action, log_prob = action_dist.sample_and_log_prob(seed=key)
+            q = ensambled_vmap(self.critics, batch.observation, action)
+            target = jym.tree.map_distribution(
+                self._compute_soft_target, action_dist, log_prob, q
+            )
+            return -jym.tree.mean(target)
+
+        actor_grads = __sac_actor_loss(self.actor, trajectory_batch)
+
+        updates, optimizer_state = trainer.optimizer["actor"].update(
+            actor_grads, self.optimizer_state["actor"]
+        )
+        new_actor = eqx.apply_updates(self.actor, updates)
+        optimizer_state = {**self.optimizer_state, "actor": optimizer_state}
+        return self.replace(actor=new_actor, optimizer_state=optimizer_state)
+
+    def update_critics_params(self, key, trajectory_batch: Transition, trainer: "SAC"):
+        @eqx.filter_grad
+        def __sac_qnet_loss(params, batch: Transition):
+            q_out = jax.vmap(params)(batch.observation, batch.action)
+            q_taken = jym.tree.gather_actions(q_out, batch.action)
+            q_taken = jym.tree.batch_sum(q_taken)
+            q_loss = optax.losses.huber_loss(q_taken, q_target)
+            return jym.tree.mean(q_loss)
+
+        action_dist = jax.vmap(self.actor)(trajectory_batch.next_observation)
+        action, action_log_prob = action_dist.sample_and_log_prob(seed=key)
+        q = ensambled_vmap(
+            self.critics_target, trajectory_batch.next_observation, action
+        )
+        target = jym.tree.map_distribution(
+            self._compute_soft_target, action_dist, action_log_prob, q
+        )
+        target = jym.tree.batch_sum(target)
+        q_target = (
+            trajectory_batch.reward
+            + (1.0 - trajectory_batch.terminated) * trainer.gamma * target
+        )
+        grads = jax.vmap(__sac_qnet_loss, in_axes=(0, None))(
+            self.critics, trajectory_batch
+        )
+        updates, optimizer_state = trainer.optimizer["critics"].update(
+            grads, self.optimizer_state["critics"]
+        )
+        new_critics = eqx.apply_updates(self.critics, updates)
+
+        new_critics_target = jax.tree.map(
+            lambda x, y: trainer.tau * x + (1 - trainer.tau) * y,
+            self.critics_target,
+            new_critics,
+        )
+        optimizer_state = {**self.optimizer_state, "critics": optimizer_state}
+        return self.replace(
+            critics=new_critics,
+            critics_target=new_critics_target,
+            optimizer_state=optimizer_state,
+        )
+
+    def update_alpha_params(self, key, trajectory_batch: Transition, trainer: "SAC"):
+        @eqx.filter_grad
+        def __sac_alpha_loss(params: Alpha, batch: Transition):
+            def alpha_loss_per_action_dist(action_dist):
+                if isinstance(
+                    action_dist, distrax.Categorical
+                ):  # TODO: pi weighing here
+                    log_probs = jnp.log(action_dist.probs + 1e-8)
+                    action_dim = jnp.prod(jnp.array(log_probs.shape[1:]))
+                    action_dim = jnp.log(1 / action_dim)
+                else:  # Continuous action space
+                    _, log_probs = action_dist.sample_and_log_prob(seed=key)
+                    action_dim = jnp.prod(jnp.array(batch.action.shape[1:]))
+
+                count = jym.tree.get_first(self.optimizer_state["alpha"], "count")
+                target_entropy_scale = trainer.target_entropy_scale_schedule(count)
+                target_entropy = -(target_entropy_scale * action_dim)
+                return -jnp.mean(params() * (log_probs + target_entropy))
+
+            action_dist = jax.vmap(self.actor)(trajectory_batch.observation)
+            loss = jym.tree.map_distribution(alpha_loss_per_action_dist, action_dist)
+            loss = jym.tree.mean(loss)
+            return loss
+
+        alpha_grads = __sac_alpha_loss(self.alpha, trajectory_batch)
+
+        updates, optimizer_state = trainer.optimizer["alpha"].update(
+            alpha_grads, self.optimizer_state["alpha"]
+        )
+        new_alpha = eqx.apply_updates(self.alpha, updates)
+        optimizer_state = {**self.optimizer_state, "alpha": optimizer_state}
+        return self.replace(alpha=new_alpha, optimizer_state=optimizer_state)
+
+    def update_normalizer(self, trajectory_batch: Transition):
+        updated_normalizer = self.normalizer.update(trajectory_batch)
+        return self.replace(normalizer=updated_normalizer)
+
+    def normalize_observation(self, observations: PyTree):
+        return self.normalizer.normalize_obs(observations)
+
+    def normalize_reward(self, rewards: PyTree):
+        return self.normalizer.normalize_reward(rewards)
 
 
 class SAC(RLAlgorithm):
@@ -65,16 +225,43 @@ class SAC(RLAlgorithm):
     This implementation uses soft target updates, a replay buffer, and a target entropy scale with optional annealing.
     """
 
-    state: SACState = eqx.field(default=None)
-    optimizer_actor: optax.GradientTransformation = eqx.field(static=True, default=None)
-    optimizer_critics: optax.GradientTransformation = eqx.field(
-        static=True, default=None
-    )
+    agent: SACAgent = eqx.field(default=None)
 
-    learning_rate_actor: float = 3e-3
-    learning_rate_critics: float = 3e-4
-    anneal_learning_rate_actor: bool | float = eqx.field(static=True, default=True)
-    anneal_learning_rate_critics: bool | float = eqx.field(static=True, default=True)
+    learning_rate_actor_start: float = 3e-3
+    learning_rate_actor_end: float | None = eqx.field(static=True, default=None)
+    learning_rate_critics_start: float = 3e-4
+    learning_rate_critics_end: float | None = eqx.field(static=True, default=None)
+    learning_rate_alpha_start: float = 3e-4
+    learning_rate_alpha_end: float | None = eqx.field(static=True, default=None)
+
+    @property
+    def optimizer(self):
+        def _create_optimizer(lr_schedule: Schedule):
+            return optax.chain(
+                optax.clip_by_global_norm(self.max_grad_norm),
+                optax.adabelief(learning_rate=lr_schedule),
+            )
+
+        actor_schedule = Schedule(
+            self.learning_rate_actor_start,
+            self.learning_rate_actor_end,
+            self.num_training_updates_actor,
+        )
+        critics_schedule = Schedule(
+            self.learning_rate_critics_start,
+            self.learning_rate_critics_end,
+            self.num_training_updates_critics,
+        )
+        alpha_schedule = Schedule(
+            self.learning_rate_alpha_start,
+            self.learning_rate_alpha_end,
+            self.num_training_updates_actor,
+        )
+        return {
+            "actor": _create_optimizer(actor_schedule),
+            "critics": _create_optimizer(critics_schedule),
+            "alpha": _create_optimizer(alpha_schedule),
+        }
 
     gamma: float = 0.99
     max_grad_norm: float = 0.5
@@ -84,31 +271,31 @@ class SAC(RLAlgorithm):
     batch_size: int = 128
     init_alpha: float = 0.2
     learn_alpha: bool = eqx.field(static=True, default=True)
-    target_entropy_scale: float = 0.5
-    anneal_entropy_scale: bool | float = eqx.field(static=True, default=False)
+    target_entropy_scale_start: float = 0.5
+    target_entropy_scale_end: float | None = eqx.field(static=True, default=None)
     tau: float = 0.95
 
     actor_num_epochs: int = eqx.field(static=True, default=1)
     actor_num_minibatches: int = eqx.field(static=True, default=1)
     critics_num_epochs: int = eqx.field(static=True, default=8)
     critics_num_minibatches: int = eqx.field(static=True, default=1)
-
+    alpha_num_epochs: int = eqx.field(static=True, default=1)
+    alpha_num_minibatches: int = eqx.field(static=True, default=1)
     total_timesteps: int = eqx.field(static=True, default=int(1e6))
     num_envs: int = eqx.field(static=True, default=8)
 
     normalize_observations: bool = eqx.field(static=True, default=False)
     normalize_rewards: bool = eqx.field(static=True, default=False)
-
     actor_kwargs: dict[str, Any] = eqx.field(
         static=True, default_factory=lambda: {"continuous_output_dist": "tanhNormal"}
     )
 
     @property
-    def _target_entropy_scale_schedule(self):
-        return _create_schedule(
-            self.anneal_entropy_scale,
-            self.target_entropy_scale,
-            self.num_training_updates_actor,
+    def target_entropy_scale_schedule(self):
+        return Schedule(
+            self.target_entropy_scale_start,
+            self.target_entropy_scale_end,
+            self.num_training_updates_alpha,
         )
 
     @property
@@ -129,59 +316,12 @@ class SAC(RLAlgorithm):
             self.num_iterations * self.critics_num_epochs * self.critics_num_minibatches
         )
 
-    @staticmethod
-    def get_action(
-        key: PRNGKeyArray, state: SACState, observation, deterministic: bool = False
-    ) -> Array:
-        observation = state.normalizer.normalize_obs(observation)
-        action_dist = state.actor(observation)
-        if deterministic:
-            return action_dist.mode()
-        return action_dist.sample(seed=key)
+    @property
+    def num_training_updates_alpha(self):
+        return self.num_iterations * self.alpha_num_epochs * self.alpha_num_minibatches
 
-    def init_state(self, key: PRNGKeyArray, env: Environment) -> "SAC":
-        if getattr(env, "multi_agent", False) and self.auto_upgrade_multi_agent:
-            self = self.__make_multi_agent__()
-
-        if self.optimizer_actor is None:
-            self = replace(
-                self,
-                optimizer_actor=optax.chain(
-                    optax.clip_by_global_norm(self.max_grad_norm),
-                    optax.adabelief(
-                        learning_rate=_create_schedule(
-                            self.anneal_learning_rate_actor,
-                            self.learning_rate_actor,
-                            self.num_training_updates_actor,
-                        )
-                    ),
-                ),
-            )
-
-        if self.optimizer_critics is None:
-            self = replace(
-                self,
-                optimizer_critics=optax.chain(
-                    optax.clip_by_global_norm(self.max_grad_norm),
-                    optax.adabelief(
-                        learning_rate=_create_schedule(
-                            self.anneal_learning_rate_critics,
-                            self.learning_rate_critics,
-                            self.num_training_updates_critics,
-                        )
-                    ),
-                ),
-            )
-
-        agent_states = self._make_agent_state(
-            key=key,
-            obs_space=env.observation_space,
-            output_space=env.action_space,
-            actor_kwargs=self.actor_kwargs,
-            critic_kwargs=self.critic_kwargs,
-        )
-
-        return replace(self, state=agent_states)
+    def init_agent(self, key: PRNGKeyArray, env: Environment) -> "SAC":
+        return replace(self, agent=SACAgent(key=key, env=env, trainer=self))
 
     def train(self, key: PRNGKeyArray, env: Environment, **hyperparams) -> "SAC":
         @scan_callback(
@@ -203,22 +343,18 @@ class SAC(RLAlgorithm):
                 rollout_state, env
             )
 
-            # Post-process the trajectory batch: normalization update (possibly per-agent)
-            updated_state = self._postprocess_rollout(trajectory_batch, self.state)
+            # Update normalizer
+            agent = self.agent.update_normalizer(trajectory_batch)
 
             # Add new data to buffer & Sample update batch from the buffer
             buffer = buffer.insert(trajectory_batch)
             train_batch = buffer.sample(rng)
 
             # Update
-            updated_state = self._update_agent_state(
-                rng,
-                updated_state,  # <-- use updated_state w/ updated norm
-                train_batch,
-            )
+            updated_agent = self._update_agent_state(rng, agent, train_batch)
 
             metric = trajectory_batch.info or {}
-            self = replace(self, state=updated_state)
+            self = replace(self, agent=updated_agent)
             runner_state = (self, buffer, env_state, last_obs, rng)
             return runner_state, metric
 
@@ -226,7 +362,7 @@ class SAC(RLAlgorithm):
         self = replace(self, **hyperparams)
 
         if not self.is_initialized:
-            self = self.init_state(key, env)
+            self = self.init_agent(key, env)
 
         obsv, env_state = env.reset(jax.random.split(key, self.num_envs))
 
@@ -255,9 +391,7 @@ class SAC(RLAlgorithm):
 
             # select an action
             sample_key = jax.random.split(sample_key, self.num_envs)
-            action = jax.vmap(self.get_action, in_axes=(0, None, 0))(
-                sample_key, self.state, last_obs
-            )
+            action = jax.vmap(self.get_action, in_axes=(0, 0))(sample_key, last_obs)
 
             # take a step in the environment
             step_key = jax.random.split(step_key, self.num_envs)
@@ -290,138 +424,9 @@ class SAC(RLAlgorithm):
 
         return rollout_state, trajectory_batch
 
-    def _postprocess_rollout(
-        self, trajectory_batch: Transition, current_state: SACState
-    ) -> SACState:
-        """
-        1) Returns updated normalization based on the new trajectory batch.
-        """
-        # Update normalization params
-        updated_state = replace(
-            current_state, normalizer=current_state.normalizer.update(trajectory_batch)
-        )
-
-        return updated_state
-
     def _update_agent_state(
-        self, key: PRNGKeyArray, current_state: SACState, train_batch: Transition
-    ) -> SACState:
-        def _compute_soft_target(action_dist, action_log_probs, q_1, q_2):
-            def discrete_soft_target(action_probs, q_1, q_2):
-                action_log_prob = jnp.log(action_probs + 1e-8)
-                min_q = jnp.minimum(q_1, q_2)
-                target = min_q - current_state.alpha() * action_log_prob
-                weighted_target = (action_probs * target).sum(axis=-1)
-                return weighted_target
-
-            def continuous_soft_target(action_log_probs, q_1, q_2):
-                min_q = jnp.minimum(q_1, q_2)
-                return min_q - current_state.alpha() * action_log_probs
-
-            if isinstance(action_dist, distrax.Categorical):
-                return discrete_soft_target(action_dist.probs, q_1, q_2)
-            return continuous_soft_target(action_log_probs, q_1, q_2)
-
-        def update_critics(current_state: SACState, batch: Transition):
-            @eqx.filter_grad
-            def __sac_qnet_loss(params, batch: Transition):
-                q_out = jax.vmap(params)(batch.observation, batch.action)
-                q_taken = jym.tree.gather_actions(q_out, batch.action)
-                q_taken = jym.tree.batch_sum(q_taken)
-                q_loss = optax.losses.huber_loss(q_taken, q_target)
-                return jym.tree.mean(q_loss)
-
-            action_dist = jax.vmap(current_state.actor)(batch.next_observation)
-            action, action_log_prob = action_dist.sample_and_log_prob(seed=keys[3])
-            q_1_target = jax.vmap(current_state.critic1_target)(
-                batch.next_observation, action
-            )
-            q_2_target = jax.vmap(current_state.critic2_target)(
-                batch.next_observation, action
-            )
-            target = jym.tree.map_distribution(
-                _compute_soft_target,
-                action_dist,
-                action_log_prob,
-                q_1_target,
-                q_2_target,
-            )
-            target = jym.tree.batch_sum(target)
-            q_target = batch.reward + (1.0 - batch.terminated) * self.gamma * target
-            critic_1_grads = __sac_qnet_loss(current_state.critic1, batch)
-            critic_2_grads = __sac_qnet_loss(current_state.critic2, batch)
-            updates, optimizer_state = self.optimizer_critics.update(
-                (critic_1_grads, critic_2_grads),
-                current_state.optimizer_state_critics,
-            )
-            new_critic1, new_critic2 = eqx.apply_updates(
-                (current_state.critic1, current_state.critic2),
-                updates,
-            )
-            return replace(
-                current_state,
-                critic1=new_critic1,
-                critic2=new_critic2,
-                optimizer_state_critics=optimizer_state,
-            ), None
-
-        def update_actor_and_alpha(current_state: SACState, batch: Transition):
-            @eqx.filter_grad
-            def __sac_actor_loss(params, batch: Transition):
-                action_dist = jax.vmap(params)(batch.observation)
-                action, log_prob = action_dist.sample_and_log_prob(seed=keys[4])
-                q_1 = jax.vmap(current_state.critic1)(batch.observation, action)
-                q_2 = jax.vmap(current_state.critic2)(batch.observation, action)
-                target = jym.tree.map_distribution(
-                    _compute_soft_target, action_dist, log_prob, q_1, q_2
-                )
-                return -jym.tree.mean(target)
-
-            @eqx.filter_grad
-            def __sac_alpha_loss(params: Alpha, batch: Transition):
-                def alpha_loss_per_action_dist(action_dist):
-                    if isinstance(action_dist, distrax.Categorical):
-                        log_probs = jnp.log(action_dist.probs + 1e-8)
-                        action_dim = jnp.prod(jnp.array(log_probs.shape[1:]))
-                        action_dim = jnp.log(1 / action_dim)
-                    else:  # Continuous action space
-                        _, log_probs = action_dist.sample_and_log_prob(seed=keys[5])
-                        action_dim = jnp.prod(jnp.array(batch.action.shape[1:]))
-
-                    update_count = jym.tree.get_first(
-                        current_state.optimizer_state_actor, "count"
-                    )
-                    target_entropy_scale = self._target_entropy_scale_schedule(
-                        update_count
-                    )
-                    target_entropy = -(target_entropy_scale * action_dim)
-                    return -jnp.mean(params() * (log_probs + target_entropy))
-
-                action_dist = jax.vmap(current_state.actor)(batch.observation)
-                loss = jym.tree.map_distribution(
-                    alpha_loss_per_action_dist, action_dist
-                )
-                loss = jym.tree.mean(loss)
-                return loss
-
-            actor_grads = __sac_actor_loss(current_state.actor, batch)
-            alpha_grads = __sac_alpha_loss(current_state.alpha, batch)
-
-            updates, optimizer_state = self.optimizer_actor.update(
-                (actor_grads, alpha_grads),
-                current_state.optimizer_state_actor,
-            )
-            new_actor, new_alpha = eqx.apply_updates(
-                (current_state.actor, current_state.alpha),
-                updates,
-            )
-            return replace(
-                current_state,
-                actor=new_actor,
-                alpha=new_alpha if self.learn_alpha else current_state.alpha,
-                optimizer_state_actor=optimizer_state,
-            ), None
-
+        self, key: PRNGKeyArray, current_state: SACAgent, train_batch: Transition
+    ) -> SACAgent:
         # Normalize all used inputs, if normalization is disabled, these are no-ops
         normalizer = current_state.normalizer
         train_batch = replace(
@@ -431,102 +436,65 @@ class SAC(RLAlgorithm):
             reward=normalizer.normalize_reward(train_batch.reward),
         )
 
-        keys = jax.random.split(key, 5)
+        def scan_critics_epoch_update(current_agent: SACAgent, key):
+            minibatches = train_batch.make_minibatches(
+                key, self.critics_num_minibatches
+            )
 
-        # Update the critics for each minibatch and epoch
-        critic_train_batches = train_batch.make_minibatches(
-            keys[1],
-            self.critics_num_minibatches,
-            self.critics_num_epochs,
-            n_batch_axis=1,
-        )
-        updated_state, _ = jax.lax.scan(
-            update_critics, current_state, critic_train_batches
-        )
+            def do_update(key_and_current_agent, minibatch):
+                key, current_agent = key_and_current_agent
+                key, next_key = jax.random.split(key, 2)
+                updated_agent = current_agent.update_critics_params(
+                    key, minibatch, self
+                )
+                return (next_key, updated_agent), None
 
-        # Update the actor and Alpha for each minibatch and epoch
-        actor_train_batches = train_batch.make_minibatches(
-            keys[2],
-            self.actor_num_minibatches,
-            self.actor_num_epochs,
-            n_batch_axis=1,
-        )
-        updated_state, _ = jax.lax.scan(
-            update_actor_and_alpha, updated_state, actor_train_batches
-        )
+            (_, updated_agent), _ = jax.lax.scan(
+                do_update, (key, current_agent), minibatches
+            )
+            return updated_agent, None
 
-        # Update target networks
-        new_critic1_target, new_critic2_target = jax.tree.map(
-            lambda x, y: self.tau * x + (1 - self.tau) * y,
-            (current_state.critic1_target, current_state.critic2_target),
-            (updated_state.critic1, updated_state.critic2),
+        update_keys = jax.random.split(key, self.critics_num_epochs)
+        updated_agent, _ = jax.lax.scan(
+            scan_critics_epoch_update, current_state, update_keys
         )
 
-        return replace(
-            updated_state,
-            critic1_target=new_critic1_target,
-            critic2_target=new_critic2_target,
+        def scan_actor_epoch_update(current_agent: SACAgent, key):
+            minibatches = train_batch.make_minibatches(key, self.actor_num_minibatches)
+
+            def do_update(key_and_current_agent, minibatch):
+                key, current_agent = key_and_current_agent
+                key, next_key = jax.random.split(key, 2)
+                updated_agent = current_agent.update_actor_params(key, minibatch, self)
+                return (next_key, updated_agent), None
+
+            (_, updated_agent), _ = jax.lax.scan(
+                do_update, (key, current_agent), minibatches
+            )
+            return updated_agent, None
+
+        update_keys = jax.random.split(key, self.actor_num_epochs)
+        updated_agent, _ = jax.lax.scan(
+            scan_actor_epoch_update, updated_agent, update_keys
         )
 
-    def _make_agent_state(
-        self,
-        key: PRNGKeyArray,
-        obs_space: jym.Space,
-        output_space: jym.Space,
-        actor_kwargs: dict[str, Any],
-        critic_kwargs: dict[str, Any],
-    ):
-        actor_key, critic1_key, critic2_key = jax.random.split(key, 3)
-        actor = ActorNetwork(
-            key=actor_key,
-            obs_space=obs_space,
-            output_space=output_space,
-            **actor_kwargs,
-        )
-        critic1 = QValueNetwork(
-            key=critic1_key,
-            obs_space=obs_space,
-            output_space=output_space,
-            **critic_kwargs,
-        )
-        critic2 = QValueNetwork(
-            key=critic2_key,
-            obs_space=obs_space,
-            output_space=output_space,
-            **critic_kwargs,
-        )
-        critic1_target = jax.tree.map(lambda x: x, critic1)
-        critic2_target = jax.tree.map(lambda x: x, critic2)
-        alpha = Alpha(jnp.log(self.init_alpha))
+        def scan_alpha_epoch_update(current_agent: SACAgent, key):
+            minibatches = train_batch.make_minibatches(key, self.alpha_num_minibatches)
 
-        # Alpha shares the same optimizer
-        optimizer_state_actor = self.optimizer_actor.init(
-            eqx.filter((actor, alpha), eqx.is_inexact_array)
-        )
-        optimizer_state_critics = self.optimizer_critics.init(
-            eqx.filter((critic1, critic2), eqx.is_inexact_array)
+            def do_update(key_and_current_agent, minibatch):
+                key, current_agent = key_and_current_agent
+                key, next_key = jax.random.split(key, 2)
+                updated_agent = current_agent.update_alpha_params(key, minibatch, self)
+                return (next_key, updated_agent), None
+
+            (_, updated_agent), _ = jax.lax.scan(
+                do_update, (key, current_agent), minibatches
+            )
+            return updated_agent, None
+
+        update_keys = jax.random.split(key, self.alpha_num_epochs)
+        updated_agent, _ = jax.lax.scan(
+            scan_alpha_epoch_update, updated_agent, update_keys
         )
 
-        dummy_obs = jax.tree.map(
-            lambda space: space.sample(jax.random.PRNGKey(0)),
-            obs_space,
-        )
-        normalization_state = Normalizer(
-            dummy_obs,
-            normalize_obs=self.normalize_observations,
-            normalize_rew=self.normalize_rewards,
-            gamma=self.gamma,
-            rew_shape=(self.num_steps, self.num_envs),
-        )
-
-        return SACState(
-            actor=actor,
-            critic1=critic1,
-            critic2=critic2,
-            critic1_target=critic1_target,
-            critic2_target=critic2_target,
-            alpha=alpha,
-            optimizer_state_actor=optimizer_state_actor,
-            optimizer_state_critics=optimizer_state_critics,
-            normalizer=normalization_state,
-        )
+        return updated_agent

--- a/src/jaxnasium/algorithms/_sac.py
+++ b/src/jaxnasium/algorithms/_sac.py
@@ -97,21 +97,15 @@ class SACAgent(RLAgent):
             return action_dist.mode()
         return action_dist.sample(seed=key)
 
-    def _compute_soft_target(self, action_dist, action_log_probs, q):
-        def discrete_soft_target(action_probs, q):
-            action_log_prob = jnp.log(action_probs + 1e-8)
-            min_q = q.min(axis=0)
-            target = min_q - self.alpha() * action_log_prob
-            weighted_target = (action_probs * target).sum(axis=-1)
-            return weighted_target
-
-        def continuous_soft_target(action_log_probs, q):
-            min_q = q.min(axis=0)
-            return min_q - self.alpha() * action_log_probs
-
+    def _compute_soft_target(self, action_dist, q, action_log_prob):
         if isinstance(action_dist, distrax.Categorical):
-            return discrete_soft_target(action_dist.probs, q)
-        return continuous_soft_target(action_log_probs, q)
+            action_log_prob = jnp.log(action_dist.probs + 1e-8)
+        min_q = q.min(axis=0)
+        target = min_q - self.alpha() * action_log_prob
+        if isinstance(action_dist, distrax.Categorical):
+            weighted_target = (action_dist.probs * target).sum(axis=-1)
+            return weighted_target
+        return target
 
     def update_actor_params(self, key, trajectory_batch: Transition, trainer: "SAC"):
         @eqx.filter_grad
@@ -120,8 +114,9 @@ class SACAgent(RLAgent):
             action, log_prob = action_dist.sample_and_log_prob(seed=key)
             q = ensambled_vmap(self.critics, batch.observation, action)
             target = jym.tree.map_distribution(
-                self._compute_soft_target, action_dist, log_prob, q
+                self._compute_soft_target, action_dist, q, log_prob
             )
+            target = jym.tree.batch_sum(target)
             return -jym.tree.mean(target)
 
         actor_grads = __sac_actor_loss(self.actor, trajectory_batch)
@@ -143,12 +138,12 @@ class SACAgent(RLAgent):
             return jym.tree.mean(q_loss)
 
         action_dist = jax.vmap(self.actor)(trajectory_batch.next_observation)
-        action, action_log_prob = action_dist.sample_and_log_prob(seed=key)
+        action, log_prob = action_dist.sample_and_log_prob(seed=key)
         q = ensambled_vmap(
             self.critics_target, trajectory_batch.next_observation, action
         )
         target = jym.tree.map_distribution(
-            self._compute_soft_target, action_dist, action_log_prob, q
+            self._compute_soft_target, action_dist, q, log_prob
         )
         target = jym.tree.batch_sum(target)
         q_target = (
@@ -178,27 +173,31 @@ class SACAgent(RLAgent):
     def update_alpha_params(self, key, trajectory_batch: Transition, trainer: "SAC"):
         @eqx.filter_grad
         def __sac_alpha_loss(params: Alpha, batch: Transition):
-            def alpha_loss_per_action_dist(action_dist):
-                if isinstance(
-                    action_dist, distrax.Categorical
-                ):  # TODO: pi weighing here
-                    log_probs = jnp.log(action_dist.probs + 1e-8)
-                    action_dim = jnp.prod(jnp.array(log_probs.shape[1:]))
-                    action_dim = jnp.log(1 / action_dim)
+            def _compute_alpha_signal(action_dist):
+                target_entropy = trainer.target_entropy
+                if isinstance(action_dist, distrax.Categorical):
+                    action_probs = action_dist.probs
+                    log_probs = jnp.log(action_probs + 1e-8)
+                    if target_entropy is None:
+                        action_dim = jnp.prod(jnp.array(log_probs.shape[1:]))
+                        target_entropy = (
+                            target_entropy_scale * 0.5 * jnp.log(action_dim)
+                        )
+                    return (action_probs * (log_probs + target_entropy)).sum(axis=-1)
                 else:  # Continuous action space
                     _, log_probs = action_dist.sample_and_log_prob(seed=key)
-                    action_dim = jnp.prod(jnp.array(batch.action.shape[1:]))
+                    if target_entropy is None:
+                        action_dim = jnp.prod(jnp.array(batch.action.shape[1:]))
+                        target_entropy = target_entropy_scale * -action_dim
+                    return log_probs + target_entropy
 
-                count = jym.tree.get_first(self.optimizer_state["alpha"], "count")
-                target_entropy_scale = trainer.target_entropy_scale_schedule(count)
-                target_entropy = -(target_entropy_scale * action_dim)
-                return -jnp.mean(params() * (log_probs + target_entropy))
+            signals = jym.tree.map_distribution(_compute_alpha_signal, action_dist)
+            signals = jym.tree.batch_sum(signals)
+            return -jnp.mean(params() * signals)
 
-            action_dist = jax.vmap(self.actor)(trajectory_batch.observation)
-            loss = jym.tree.map_distribution(alpha_loss_per_action_dist, action_dist)
-            loss = jym.tree.mean(loss)
-            return loss
-
+        count = jym.tree.get_first(self.optimizer_state["alpha"], "count")
+        target_entropy_scale = trainer.target_entropy_scale_schedule(count)
+        action_dist = jax.vmap(self.actor)(trajectory_batch.observation)
         alpha_grads = __sac_alpha_loss(self.alpha, trajectory_batch)
 
         updates, optimizer_state = trainer.optimizer["alpha"].update(
@@ -231,7 +230,7 @@ class SAC(RLAlgorithm):
     learning_rate_actor_end: float | None = eqx.field(static=True, default=None)
     learning_rate_critics_start: float = 3e-4
     learning_rate_critics_end: float | None = eqx.field(static=True, default=None)
-    learning_rate_alpha_start: float = 3e-4
+    learning_rate_alpha_start: float = 3e-3
     learning_rate_alpha_end: float | None = eqx.field(static=True, default=None)
 
     @property
@@ -265,13 +264,13 @@ class SAC(RLAlgorithm):
 
     gamma: float = 0.99
     max_grad_norm: float = 0.5
-    # update_every: int = eqx.field(static=True, default=128)
-    num_steps: int = eqx.field(static=True, default=16)
-    replay_buffer_size: int = 5000
-    batch_size: int = 128
+    num_steps: int = eqx.field(static=True, default=64)
+    replay_buffer_size: int = 500_000
+    batch_size: int = 512
     init_alpha: float = 0.2
     learn_alpha: bool = eqx.field(static=True, default=True)
-    target_entropy_scale_start: float = 0.5
+    target_entropy: float | None = eqx.field(static=True, default=None)
+    target_entropy_scale_start: float = 1.0
     target_entropy_scale_end: float | None = eqx.field(static=True, default=None)
     tau: float = 0.95
 

--- a/src/jaxnasium/algorithms/_sac.py
+++ b/src/jaxnasium/algorithms/_sac.py
@@ -85,7 +85,7 @@ class SACAgent(RLAgent):
             normalize_obs=trainer.normalize_observations,
             normalize_rew=trainer.normalize_rewards,
             gamma=trainer.gamma,
-            rew_shape=(trainer.num_steps, trainer.num_envs),
+            rew_shape=(trainer.rollout_length, trainer.num_envs),
         )
 
     def get_action(
@@ -258,7 +258,7 @@ class SAC(RLAlgorithm):
 
     gamma: float = 0.99
     max_grad_norm: float = 0.5
-    num_steps: int = eqx.field(static=True, default=64)
+    update_every: int = eqx.field(static=True, default=512)
     replay_buffer_size: int = 50_000
     batch_size: int = 512
     init_alpha: float = 0.2
@@ -293,11 +293,11 @@ class SAC(RLAlgorithm):
 
     @property
     def num_iterations(self):
-        return int(self.total_timesteps // self.num_steps // self.num_envs)
+        return int(self.total_timesteps // self.rollout_length // self.num_envs)
 
     @property
-    def update_every(self):
-        return int(self.num_steps * self.num_envs)
+    def rollout_length(self):
+        return int(self.update_every // self.num_envs)
 
     @property
     def num_training_updates_actor(self):
@@ -395,7 +395,7 @@ class SAC(RLAlgorithm):
             )
 
             # Build a single transition. Jax.lax.scan will build the batch
-            # returning num_steps transitions.
+            # returning rollout_length transitions.
             transition = Transition(
                 observation=last_obs,
                 action=action,
@@ -410,7 +410,7 @@ class SAC(RLAlgorithm):
             return rollout_state, transition
 
         if length is None:
-            length = self.num_steps
+            length = self.rollout_length
 
         # Do rollout
         rollout_state, trajectory_batch = jax.lax.scan(

--- a/src/jaxnasium/algorithms/_sac.py
+++ b/src/jaxnasium/algorithms/_sac.py
@@ -107,24 +107,25 @@ class SACAgent(RLAgent):
     def normalize_reward(self, rewards: PyTree):
         return self.normalizer.normalize_reward(rewards)
 
-    def _compute_soft_target(self, action_dist, q, action_log_prob):
+    def _compute_soft_target(self, action_dist, q, action=None):
+        min_q = q.min(axis=0)
         if isinstance(action_dist, distrax.Categorical):
             action_log_prob = jax.nn.log_softmax(action_dist.logits)
-        min_q = q.min(axis=0)
-        target = min_q - self.alpha() * action_log_prob
-        if isinstance(action_dist, distrax.Categorical):
+            target = min_q - self.alpha() * action_log_prob
             weighted_target = (action_dist.probs * target).sum(axis=-1)
             return weighted_target
-        return target
+        assert action is not None
+        action_log_prob = action_dist.log_prob(action)
+        return min_q - self.alpha() * action_log_prob
 
     def update_actor_params(self, key, batch: Transition, trainer: "SAC"):
         @eqx.filter_grad
         def __sac_actor_loss(params, train_batch: Transition):
             action_dist = jax.vmap(params)(train_batch.observation)
-            action, log_prob = action_dist.sample_and_log_prob(seed=key)
+            action = action_dist.sample(seed=key)
             q = ensambled_vmap(self.critics, train_batch.observation, action)
             target = jym.tree.map_distribution(
-                self._compute_soft_target, action_dist, q, log_prob
+                self._compute_soft_target, action_dist, q, action
             )
             target = jym.tree.batch_sum(target)
             return -jym.tree.mean(target)
@@ -148,10 +149,10 @@ class SACAgent(RLAgent):
             return jym.tree.mean(q_loss)
 
         action_dist = jax.vmap(self.actor)(batch.next_observation)
-        action, log_prob = action_dist.sample_and_log_prob(seed=key)
+        action = action_dist.sample(seed=key)
         q = ensambled_vmap(self.critics_target, batch.next_observation, action)
         target = jym.tree.map_distribution(
-            self._compute_soft_target, action_dist, q, log_prob
+            self._compute_soft_target, action_dist, q, action
         )
         target = jym.tree.batch_sum(target)
         q_target = batch.reward + (1.0 - batch.terminated) * trainer.gamma * target
@@ -190,7 +191,7 @@ class SACAgent(RLAgent):
                 else:  # Continuous action space
                     _, log_probs = action_dist.sample_and_log_prob(seed=key)
                     if target_entropy is None:
-                        action_dim = jnp.prod(jnp.array(train_batch.action.shape[1:]))
+                        action_dim = jnp.prod(jnp.array(log_probs.shape[1:]))
                         target_entropy = target_entropy_scale * -action_dim
                     return log_probs + target_entropy
 
@@ -258,7 +259,7 @@ class SAC(RLAlgorithm):
     gamma: float = 0.99
     max_grad_norm: float = 0.5
     num_steps: int = eqx.field(static=True, default=64)
-    replay_buffer_size: int = 500_000
+    replay_buffer_size: int = 50_000
     batch_size: int = 512
     init_alpha: float = 0.2
     learn_alpha: bool = eqx.field(static=True, default=True)

--- a/src/jaxnasium/algorithms/_sac.py
+++ b/src/jaxnasium/algorithms/_sac.py
@@ -491,9 +491,10 @@ class SAC(RLAlgorithm):
             )
             return updated_agent, None
 
-        update_keys = jax.random.split(key, self.alpha_num_epochs)
-        updated_agent, _ = jax.lax.scan(
-            scan_alpha_epoch_update, updated_agent, update_keys
-        )
+        if self.learn_alpha:
+            update_keys = jax.random.split(key, self.alpha_num_epochs)
+            updated_agent, _ = jax.lax.scan(
+                scan_alpha_epoch_update, updated_agent, update_keys
+            )
 
         return updated_agent

--- a/src/jaxnasium/algorithms/networks/_agent_networks.py
+++ b/src/jaxnasium/algorithms/networks/_agent_networks.py
@@ -1,13 +1,12 @@
 import logging
 
-import distrax
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import PRNGKeyArray, PyTree
+from jaxtyping import Array, PRNGKeyArray, PyTree
 
 import jaxnasium as jym
-from jaxnasium.algorithms.utils import DistraxContainer, rl_initialization
+from jaxnasium.algorithms.utils import rl_initialization
 
 from ._architectures import MLP
 from ._input_output import AutoAgentObservationNet, AutoAgentOutputNet
@@ -70,12 +69,7 @@ class ActorNetwork(eqx.Module):
 
         x = self.obs_processor(x)
         x = self.mlp(x)
-        action_dists = self.output_layers(x, action_mask)
-        if isinstance(action_dists, distrax.Distribution):
-            return action_dists  # Single distribution
-
-        # Else return a grouped container of distributions
-        return DistraxContainer(action_dists)
+        return self.output_layers(x, action_mask)
 
 
 class ValueNetwork(eqx.Module):
@@ -158,7 +152,7 @@ class QValueNetwork(eqx.Module):
         self.mlp = rl_initialization(key_mlp, self.mlp)
         self.output_layers = rl_initialization(key_out, self.output_layers)
 
-    def __call__(self, x, action=None):
+    def __call__(self, x, action=None) -> Array | PyTree[Array]:
         action_mask = None
         if isinstance(x, jym.AgentObservation):
             action_mask = x.action_mask

--- a/src/jaxnasium/algorithms/networks/_input_output.py
+++ b/src/jaxnasium/algorithms/networks/_input_output.py
@@ -11,7 +11,7 @@ from jaxtyping import PRNGKeyArray, PyTree
 
 import jaxnasium as jym
 import jaxnasium.tree
-from jaxnasium.algorithms.utils import TanhNormalFactory
+from jaxnasium.algorithms.utils import DistraxIndependentJoint, TanhNormalFactory
 
 from ._architectures import CNN, Identity
 
@@ -170,12 +170,22 @@ class AutoAgentOutputNet(eqx.Module):
                 is_leaf=_is_callable_module,
             )
 
-        return jax.tree.map(
+        outputs = jax.tree.map(
             lambda layer, mask: layer(x, mask),
             self.networks,
             action_mask,
             is_leaf=_is_callable_module,
         )
+
+        # If outputs is a pytree of distributions, make it a Joint
+        output_dists = jax.tree.leaves(
+            outputs, is_leaf=lambda x: isinstance(x, distrax.Distribution)
+        )
+        if all(isinstance(o, distrax.Distribution) for o in output_dists):
+            if len(output_dists) != 1:
+                return DistraxIndependentJoint(outputs)
+
+        return outputs
 
 
 class DiscreteOutputNetwork(eqx.Module):

--- a/src/jaxnasium/algorithms/networks/_input_output.py
+++ b/src/jaxnasium/algorithms/networks/_input_output.py
@@ -309,7 +309,7 @@ class ContinuousOutputNetwork(eqx.Module):
 
         mean = logits[..., 0]
         log_std = logits[..., 1]
-        log_std = jnp.clip(log_std, -20, 2)
-        std = jax.nn.softplus(log_std)
+        log_std = jnp.clip(logits[..., 1], -5, 2)
+        std = jnp.exp(log_std)
 
         return self.distribution(mean, std)

--- a/src/jaxnasium/algorithms/utils/__init__.py
+++ b/src/jaxnasium/algorithms/utils/__init__.py
@@ -1,6 +1,7 @@
 from ._buffer import TransitionBuffer as TransitionBuffer
 from ._distributions import (
     DistraxContainer as DistraxContainer,
+    DistraxIndependentJoint as DistraxIndependentJoint,
     TanhNormalFactory as TanhNormalFactory,
 )
 from ._initialization import rl_initialization as rl_initialization

--- a/src/jaxnasium/algorithms/utils/__init__.py
+++ b/src/jaxnasium/algorithms/utils/__init__.py
@@ -14,4 +14,5 @@ from ._normalization import (
     RunningStatisticsState as RunningStatisticsState,
 )
 from ._scan import scan_transitions as scan_transitions
+from ._schedule import Schedule as Schedule
 from ._transition import Transition as Transition

--- a/src/jaxnasium/algorithms/utils/__init__.py
+++ b/src/jaxnasium/algorithms/utils/__init__.py
@@ -8,10 +8,7 @@ from ._logging import (
     pretty_print_network as pretty_print_network,
     scan_callback as scan_callback,
 )
-from ._multi_agent import (
-    split_key_over_agents as split_key_over_agents,
-    transform_multi_agent as transform_multi_agent,
-)
+from ._multi_agent import MultiAgentWrapper as MultiAgentWrapper
 from ._normalization import (
     Normalizer as Normalizer,
     RunningStatisticsState as RunningStatisticsState,

--- a/src/jaxnasium/algorithms/utils/_distributions.py
+++ b/src/jaxnasium/algorithms/utils/_distributions.py
@@ -1,3 +1,4 @@
+import warnings
 from functools import partial
 from typing import Callable
 
@@ -21,10 +22,51 @@ def _transpose_tree_of_tuples(r, outer_treedef):
     return jax.tree.transpose(outer_treedef, inner_treedef, r)
 
 
+class DistraxIndependentJoint(distrax.Joint):
+    """A (joint) distribution that assumes all inner distributions are independent
+    when computing entropies and log probabilities
+    """
+
+    def _wrap_each_w_independent(self) -> "DistraxIndependentJoint":
+        def _wrap_distributions(dists):
+            if isinstance(dists, distrax.Joint):
+                return DistraxIndependentJoint(_wrap_distributions(dists.distributions))
+            if isinstance(dists, distrax.Independent):
+                return dists
+            if isinstance(dists, distrax.Distribution):
+                return distrax.Independent(dists)
+            return jax.tree.map(
+                _wrap_distributions,
+                dists,
+                is_leaf=lambda x: isinstance(x, distrax.Distribution),
+            )
+
+        return DistraxIndependentJoint(_wrap_distributions(self.distributions))
+
+    def entropy(self):
+        wrapped = self._wrap_each_w_independent()
+        return super(self.__class__, wrapped).entropy()
+
+    def log_prob(self, value):
+        wrapped = self._wrap_each_w_independent()
+        return super(self.__class__, wrapped).log_prob(value)
+
+    def sample_and_log_prob(self, *, seed, sample_shape=()):
+        wrapped = self._wrap_each_w_independent()
+        return super(self.__class__, wrapped).sample_and_log_prob(
+            seed=seed, sample_shape=sample_shape
+        )
+
+
 class DistraxContainer(eqx.Module):
     """Container for (possibly nested as PyTrees) distrax distributions."""
 
     distribution: distrax.Distribution | PyTree[distrax.Distribution]
+
+    def __check_init__(self):
+        warnings.warn(
+            "DistraxContainer is deprecated. Please use DistraxIndependentJoint instead."
+        )
 
     def __getattr__(self, name):
         if isinstance(self.distribution, distrax.Distribution):
@@ -101,10 +143,19 @@ class DistraxContainer(eqx.Module):
         )
 
 
+class Tanh(distrax.Tanh):
+    # https://github.com/google-deepmind/distrax/issues/216
+    def inverse_and_log_det(self, y):
+        # tanh.log_prob may fail due to machine precision
+        eps = jnp.finfo(y.dtype).eps
+        y = jnp.clip(y, -1 + eps, 1 - eps)
+        return super().inverse_and_log_det(y)
+
+
 class TanhNormal(distrax.Transformed):
     def __init__(self, mean, std, shift=0.0, scale=1.0):
         dist = distrax.Normal(loc=mean, scale=std)
-        tanh = distrax.Tanh()
+        tanh = Tanh()
         scaler = distrax.ScalarAffine(shift=shift, scale=scale)
         super().__init__(dist, distrax.Chain([scaler, tanh]))
         self._mean = mean

--- a/src/jaxnasium/algorithms/utils/_distributions.py
+++ b/src/jaxnasium/algorithms/utils/_distributions.py
@@ -106,7 +106,7 @@ class TanhNormal(distrax.Transformed):
         dist = distrax.Normal(loc=mean, scale=std)
         tanh = distrax.Tanh()
         scaler = distrax.ScalarAffine(shift=shift, scale=scale)
-        super().__init__(dist, distrax.Chain([tanh, scaler]))
+        super().__init__(dist, distrax.Chain([scaler, tanh]))
         self._mean = mean
         self._std = std
         self._shift = shift

--- a/src/jaxnasium/algorithms/utils/_multi_agent.py
+++ b/src/jaxnasium/algorithms/utils/_multi_agent.py
@@ -1,4 +1,3 @@
-from functools import partial
 from typing import Any, Optional
 
 import equinox as eqx
@@ -76,7 +75,6 @@ def map_multi_agent(
     # Transition (Also as output)
     # MultiAgentWrapper (Also as output)
 
-    processed_arguments = []
     arguments = [tree] + list(rest)
 
     # infer agent structure if not provided
@@ -84,24 +82,38 @@ def map_multi_agent(
         first_arg = next((arg for arg in arguments if not _is_prng_key(arg)), None)
         _, agent_structure = eqx.tree_flatten_one_level(first_arg)
 
-    for item in arguments:
-        if _is_prng_key(item):
-            processed_arguments.append(
-                jym.tree.split_key_like_structure(item, agent_structure)
-            )
-        elif isinstance(item, Transition):
-            processed_arguments.append(item.view_transposed)
-        elif isinstance(item, MultiAgentWrapper):
-            processed_arguments.append(item.agents)
+    def _process_item(el):
+        if _is_prng_key(el):
+            return jym.tree.split_key_like_structure(el, agent_structure)
+        elif isinstance(el, Transition):
+            return el.view_transposed
+        elif isinstance(el, MultiAgentWrapper):
+            return el.agents
         else:
-            processed_arguments.append(to_per_agent(item, agent_structure))
+            return to_per_agent(el, agent_structure)
 
-    # Any kwargs must be duplicated for each agent:
+    # Process args:
+    processed_arguments = [_process_item(item) for item in arguments]
 
+    # Process kwargs:
     if kwargs:
-        f = partial(f, **kwargs)
+        processed_kwargs = {k: _process_item(v) for k, v in kwargs.items()}
+        kw_keys = list(processed_kwargs.keys())
+        processed_kwargs = jym.tree.map_one_level(
+            lambda *vals: dict(zip(kw_keys, vals)),
+            *[processed_kwargs[k] for k in kw_keys],
+        )
 
-    result = jym.tree.map_one_level(f, *processed_arguments)
+        def _new_call(*args_w_kw_dict):
+            *args, kw_dict = args_w_kw_dict
+            return f(*args, **kw_dict)
+
+        result = jym.tree.map_one_level(
+            _new_call, *processed_arguments, processed_kwargs
+        )
+
+    else:
+        result = jym.tree.map_one_level(f, *processed_arguments)
 
     # Now the ouput can contain:
     # a PyTree of Agents originally a MultiAgentWrapper → re-wrap in MultiAgentWrapper

--- a/src/jaxnasium/algorithms/utils/_multi_agent.py
+++ b/src/jaxnasium/algorithms/utils/_multi_agent.py
@@ -145,6 +145,9 @@ class MultiAgentWrapper(eqx.Module):
         except Exception:
             return False
 
+    def __call__(self, *args, **kwargs):
+        return self.__getattr__("__call__")(*args, **kwargs)
+
     def __getattr__(self, name: str):
         agents = self.agents
         ref_structure = self._structure
@@ -166,6 +169,13 @@ class MultiAgentWrapper(eqx.Module):
                 )
 
             return multi_agent_dispatcher
+
+        elif isinstance(first_attr, eqx.Module):
+            return MultiAgentWrapper(
+                map_multi_agent(
+                    lambda a: getattr(a, name), agents, agent_structure=ref_structure
+                )
+            )
 
         return map_multi_agent(
             lambda a: getattr(a, name), agents, agent_structure=ref_structure

--- a/src/jaxnasium/algorithms/utils/_multi_agent.py
+++ b/src/jaxnasium/algorithms/utils/_multi_agent.py
@@ -1,26 +1,14 @@
-import functools
-import inspect
-from typing import Callable, List, Optional
+from functools import partial
+from typing import Any, Optional
 
 import equinox as eqx
 import jax
-from jaxtyping import PRNGKeyArray, PyTreeDef
+from jaxtyping import PyTree, PyTreeDef
 
-from jaxnasium.tree import map_one_level, stack, unstack
+import jaxnasium as jym
 
+from .._algorithm import RLAgent
 from ._transition import Transition
-
-
-def _result_tuple_to_tuple_result(r):
-    """
-    Some functions may return tuples. Rather than returning
-    a pytree of tuples, we convert it to a tuple of pytrees.
-    """
-    one_level_leaves, structure = eqx.tree_flatten_one_level(r)
-    if isinstance(one_level_leaves[0], tuple):
-        tupled = tuple([list(x) for x in zip(*one_level_leaves)])
-        r = tuple(jax.tree.unflatten(structure, leaves) for leaves in tupled)
-    return r
 
 
 def _is_prng_key(arg):
@@ -32,152 +20,153 @@ def _is_prng_key(arg):
         return False
 
 
-def split_key_over_agents(key: PRNGKeyArray, agent_structure: PyTreeDef):
-    """
-    Given a key and a pytree structure, split the key into
-    as many keys as there are leaves in the pytree.
-    Useful when provided with a flat pytree of agents.
+def _result_tuple_to_tuple_result(r, outer_def=None):
+    if outer_def is None:
+        _, outer_def = eqx.tree_flatten_one_level(r)
+    children = outer_def.flatten_up_to(r)
+    if type(children[0]) is not tuple:
+        return r  # f returned a single value -> r already has outer structure
 
-    Similar to `optax.tree_utils.tree_split_key_like`, but operates on PyTreeDefs.
-
-    *Arguments*:
-        `key`: A PRNGKeyArray to be split.
-        `agent_structure`: A pytree structure of agents.
-    """
-    num_agents = agent_structure.num_leaves
-    keys = list(jax.random.split(key, num_agents))
-    return jax.tree.unflatten(agent_structure, keys)
+    transposed = zip(*children)  # tuple-of-(list of children)
+    return tuple(
+        _result_tuple_to_tuple_result(
+            jax.tree.unflatten(outer_def, list(group)), outer_def
+        )
+        for group in transposed
+    )
 
 
-def transform_multi_agent(
-    func: Optional[Callable] = None,
-    *,
-    shared_argnames: Optional[List[str]] = None,
-    auto_split_keys: bool = True,
-    auto_transpose_transitions: bool = True,
-) -> Callable:
-    """
-    Transformation docorator to handle multi-agent settings.
-    Essentially, this function either applies a vmap over the agents (if the agent are homogeneous)
-    or applies a `jax.tree.map` over the first level of the PyTree structure of the arguments.
+def _is_pytree_of_agents(x):
+    """Check if *x* is a pytree whose first-level leaves are all RLAgents."""
+    try:
+        leaves, _ = eqx.tree_flatten_one_level(x)
+        return all(isinstance(leaf, RLAgent) for leaf in leaves)
+    except Exception:
+        return False
 
-    Essentially, this transformation allows for writing single-agent functions that can
-    automatically be upgraded to multi-agent settings.
 
-    **Arguments**:
+def _is_pytree_of_transitions(x):
+    """Check if *x* is a pytree whose first-level leaves are all Transitions."""
+    try:
+        leaves, _ = eqx.tree_flatten_one_level(x)
+        return all(isinstance(leaf, Transition) for leaf in leaves)
+    except Exception:
+        return False
 
-    - `func`: The function to be transformed. If None, returns a decorator.
-    - `shared_argnames`: An optional list of argument names that are shared across agents. If None, the first (non-PRNGKey) argument is
-        assumed to be a per-agent argument. All arguments with the same first-level PyTree structure are also considered per-agent arguments.
-        The rest are considered shared arguments. PRNG keys that are provided as arguments are automatically split over agents.
-    - `auto_split_keys`: When enabled, provided single PRNGKeys are automatically split over the same structure as the first argument.
-    - `auto_split_transitions`: When enabled, `Transition` objects are automatically transposed before being passed to the function.
-            After the function call, the `Transition` object is reconstructed into the original structure.
 
-    **Example**:
-    ```python
-    >>> @transform_multi_agent
-    ... def get_action(key, agent, observation):
-    ...     action_dist = agent.actor(observation)
-    ...     return action_dist.sample(seed=key)
+def to_per_agent(x, ref_structure):
+    _, structure = eqx.tree_flatten_one_level(x)
+    if structure == ref_structure:
+        return x
+    return jax.tree.unflatten(ref_structure, [x] * ref_structure.num_leaves)
 
-    # Usage:
-    >>> models = {"agent0": model1, "agent1": model2}
-    >>> agent_observations = {"agent0": obs0, "agent1": obs1} # <-- Same first-level structure as `models`
-    >>> key = jax.random.PRNGKey(42) # <-- `key` inputs are automatically split over agents
-    >>> actions = get_action(agent_states, agent_observations, key)
-    >>> # Result: {"agent0": action0, "agent1": action1}
-    ```
-    """
-    assert callable(func) or func is None
 
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            sig = inspect.signature(func)
-            bound = sig.bind(*args, **kwargs)
-            bound.apply_defaults()
-            params = bound.arguments
+def map_multi_agent(
+    f,
+    tree,
+    *rest,
+    agent_structure: Optional[PyTreeDef] = None,  # pyright: ignore[reportInvalidTypeForm]
+    **kwargs,
+) -> Any:
+    # from jaxnasium.algorithms import RLAlgorithm
+    # check if any element in tree or rest is a "RLAlgorithm"
 
-            shared: set[str] = set(shared_argnames or ())
-            shared.update(k for k in ("self", "cls") if k in params)
+    # We special case these elements:
+    # PRNGKey
+    # Transition (Also as output)
+    # MultiAgentWrapper (Also as output)
 
-            _has_transposed_transition = False
+    processed_arguments = []
+    arguments = [tree] + list(rest)
 
-            # Grab the first param key that is not in shared and is not a PRNGKey
-            # We use the "first-level" PyTree structure as the "agent structure" and use it as reference
-            ref_key = next(
-                (k for k in params if k not in shared and not _is_prng_key(params[k])),
-                None,
+    # infer agent structure if not provided
+    if agent_structure is None:
+        first_arg = next((arg for arg in arguments if not _is_prng_key(arg)), None)
+        _, agent_structure = eqx.tree_flatten_one_level(first_arg)
+
+    for item in arguments:
+        if _is_prng_key(item):
+            processed_arguments.append(
+                jym.tree.split_key_like_structure(item, agent_structure)
             )
-            if ref_key is None:
-                raise ValueError("No per-agent args found in the function signature.")
-            ref_arg = params[ref_key]
-            if isinstance(ref_arg, Transition):
-                ref_structure = ref_arg.structure
-            else:
-                _, ref_structure = eqx.tree_flatten_one_level(ref_arg)
+        elif isinstance(item, Transition):
+            processed_arguments.append(item.view_transposed)
+        elif isinstance(item, MultiAgentWrapper):
+            processed_arguments.append(item.agents)
+        else:
+            processed_arguments.append(to_per_agent(item, agent_structure))
 
-            # Infer the shared arguments from the function signature if not provided
-            if shared_argnames is None:
-                for k, v in params.items():
-                    _, param_structure = eqx.tree_flatten_one_level(v)
-                    if ref_structure != param_structure:
-                        shared.add(k)
+    # Any kwargs must be duplicated for each agent:
 
-            # Auto splitting:
-            for shared_param in shared.copy():
-                arg = params[shared_param]
+    if kwargs:
+        f = partial(f, **kwargs)
 
-                if auto_split_keys and _is_prng_key(arg):
-                    params[shared_param] = split_key_over_agents(arg, ref_structure)
-                    shared.remove(shared_param)
+    result = jym.tree.map_one_level(f, *processed_arguments)
 
-                if auto_transpose_transitions and isinstance(arg, Transition):
-                    params[shared_param] = arg.view_transposed
-                    shared.remove(shared_param)
-                    _has_transposed_transition = True
+    # Now the ouput can contain:
+    # a PyTree of Agents originally a MultiAgentWrapper → re-wrap in MultiAgentWrapper
+    # a PyTree of Transitions originally a Transition → merge back into a single Transition
+    # a PyTree of tuples that we want to convert to a tuple of PyTrees (e.g. dist.sample_and_log_prob returns a tuple, which we want to preserve)
+    # out = _maybe_untranspose_transitions(out)
+    # out = _result_tuple_to_tuple_result(out)
+    # out = MultiAgentWrapper(out) if eqx.tree_is_array(out) else out
 
-            shared_params = {k: params[k] for k in shared}
-            per_agent_params = {k: params[k] for k in params if k not in shared}
+    out = _result_tuple_to_tuple_result(result)
 
-            # Prepare a function that takes only per-agent args
-            def agent_func(*agent_args):
-                per_agent_kwargs = dict(zip(per_agent_params.keys(), agent_args))
-                return func(**per_agent_kwargs, **shared_params)
+    def _process_output(o):
+        if any(isinstance(x, MultiAgentWrapper) for x in arguments):
+            if _is_pytree_of_agents(o):
+                return MultiAgentWrapper(o)
 
-            try:  # Try stack + vmap
-                first_arg = next(iter(per_agent_params.values()))
-                _, agent_structure = eqx.tree_flatten_one_level(first_arg)
-                stacked_args = {k: stack(v) for k, v in per_agent_params.items()}
-                result = jax.vmap(agent_func)(*stacked_args.values())
-                result = unstack(result, structure=agent_structure)
+        if _is_pytree_of_transitions(o):
+            return Transition.from_transposed(o)
 
-            except Exception:  # Homogeneous inputs, cannot vmap. Apply map instead.
-                result = map_one_level(agent_func, *per_agent_params.values())
+        if isinstance(o, tuple):
+            return tuple(_process_output(x) for x in o)
 
-            result = _result_tuple_to_tuple_result(result)
+        return o
 
-            if _has_transposed_transition:
-                # If a Transition was transposed, and the function
-                # returns an (updated) transpsed Transition,
-                # we need to rebuild the original structure
-                is_pytree_of_transitions = lambda x: all(
-                    isinstance(y, Transition) for y in eqx.tree_flatten_one_level(x)[0]
+    return _process_output(out)
+
+
+class MultiAgentWrapper(eqx.Module):
+    agents: PyTree
+
+    @property
+    def _structure(self) -> PyTreeDef:  # pyright: ignore[reportInvalidTypeForm]
+        """First-level pytree structure of the wrapped agents."""
+        return eqx.tree_flatten_one_level(self.agents)[1]
+
+    def _matches_structure(self, arg) -> bool:
+        """Check whether *arg*'s first-level structure matches the agent structure."""
+        try:
+            _, s = eqx.tree_flatten_one_level(arg)
+            return s == self._structure
+        except Exception:
+            return False
+
+    def __getattr__(self, name: str):
+        agents = self.agents
+        ref_structure = self._structure
+        first_agent = eqx.tree_flatten_one_level(agents)[0][0]
+        first_attr = getattr(first_agent, name)
+
+        def _is_bound_method(x):
+            return hasattr(x, "__self__") and hasattr(x, "__func__")
+
+        if _is_bound_method(first_attr):
+
+            def multi_agent_dispatcher(*args, **kwargs):
+                return map_multi_agent(
+                    lambda a, *args, **kw: getattr(a, name)(*args, **kw),
+                    self,
+                    *args,
+                    **kwargs,
+                    agent_structure=ref_structure,
                 )
-                if is_pytree_of_transitions(result):
-                    result = Transition.from_transposed(result)
-                elif isinstance(result, tuple):
-                    result_list = []
-                    for res in result:
-                        if is_pytree_of_transitions(res):
-                            result_list.append(Transition.from_transposed(res))
-                        else:
-                            result_list.append(res)
-                    result = tuple(result_list)
 
-            return result
+            return multi_agent_dispatcher
 
-        return wrapper
-
-    return decorator(func) if callable(func) else decorator
+        return map_multi_agent(
+            lambda a: getattr(a, name), agents, agent_structure=ref_structure
+        )

--- a/src/jaxnasium/algorithms/utils/_normalization.py
+++ b/src/jaxnasium/algorithms/utils/_normalization.py
@@ -171,8 +171,9 @@ class Normalizer(eqx.Module):
 
     def __init__(
         self,
-        dummy_obs: PyTree | None,
+        dummy_obs: PyTree | None = None,
         *,
+        obs_space: PyTree[jym.Space] | None = None,
         normalize_obs: bool = True,
         normalize_rew: bool = True,
         gamma: float | None = 0.99,
@@ -182,9 +183,13 @@ class Normalizer(eqx.Module):
         self.reward = None
 
         if normalize_obs:
-            assert dummy_obs is not None, (
-                "When normalizing observations, a dummy observation must be provided."
+            assert dummy_obs is not None or obs_space is not None, (
+                "When normalizing observations, a dummy observation or observation space must be provided."
             )
+            if dummy_obs is None:
+                dummy_obs = jax.tree.map(
+                    lambda space: space.sample(jax.random.PRNGKey(0)), obs_space
+                )
             if isinstance(dummy_obs, jym.AgentObservation):
                 dummy_obs = dummy_obs.observation
             self.obs = RunningStatisticsState(dummy_obs)

--- a/src/jaxnasium/algorithms/utils/_schedule.py
+++ b/src/jaxnasium/algorithms/utils/_schedule.py
@@ -1,0 +1,39 @@
+import equinox as eqx
+import jax
+import optax
+from jaxtyping import PyTree
+
+
+class Schedule(eqx.Module):
+    """A simple wrapper around optax schedules to allow for per-agent schedules in multi-agent settings.
+    Is either a constant value or a linear schedule from start to end over the course of training."""
+
+    start: float | PyTree
+    end: float | PyTree | None
+    transition_steps: int
+
+    def __call__(self, count):
+        if self.end is None:
+            return self.start
+
+        # If start is not per-agent, use end as the first argument of the tree.map:
+        if jax.tree.structure(self.start) == jax.tree.structure(0):
+            return jax.tree.map(
+                lambda end, start: optax.linear_schedule(
+                    init_value=start,
+                    end_value=end,
+                    transition_steps=self.transition_steps,
+                )(count),
+                self.end,
+                self.start,
+            )
+
+        return jax.tree.map(
+            lambda start, end: optax.linear_schedule(
+                init_value=start,
+                end_value=end,
+                transition_steps=self.transition_steps,
+            )(count),
+            self.start,
+            self.end,
+        )

--- a/src/jaxnasium/algorithms/utils/_transition.py
+++ b/src/jaxnasium/algorithms/utils/_transition.py
@@ -27,6 +27,7 @@ class Transition(eqx.Module):
     next_observation: Optional[Array] = None
     return_: Optional[Float[Array, " "]] = None
     advantage: Optional[Float[Array, "..."]] = None
+    target: Optional[Float[Array, " "]] = None
 
     @property
     def structure(self) -> PyTreeDef:  # pyright: ignore[reportInvalidTypeForm]

--- a/src/jaxnasium/algorithms/utils/_transition.py
+++ b/src/jaxnasium/algorithms/utils/_transition.py
@@ -29,6 +29,10 @@ class Transition(eqx.Module):
     advantage: Optional[Float[Array, "..."]] = None
     target: Optional[Float[Array, " "]] = None
 
+    def replace(self, **updates):
+        keys, values = zip(*updates.items())
+        return eqx.tree_at(lambda c: [c.__dict__[key] for key in keys], self, values)
+
     @property
     def structure(self) -> PyTreeDef:  # pyright: ignore[reportInvalidTypeForm]
         """

--- a/src/jaxnasium/algorithms/utils/_transition.py
+++ b/src/jaxnasium/algorithms/utils/_transition.py
@@ -1,10 +1,13 @@
 import logging
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Bool, Float, PRNGKeyArray, PyTree, PyTreeDef
+
+if TYPE_CHECKING:
+    from ._normalization import Normalizer
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +45,19 @@ class Transition(eqx.Module):
         usefull for unflattening Transition.flat.properties back to the original structure.
         """
         return jax.tree.structure(self.reward)
+
+    def normalize(self, normalizer: "Normalizer"):
+        """Normalizes the observation and rewards in the transition based on the given normalizer."""
+        if self.next_observation is not None:
+            return self.replace(
+                observation=normalizer.normalize_obs(self.observation),
+                next_observation=normalizer.normalize_obs(self.next_observation),
+                reward=normalizer.normalize_reward(self.reward),
+            )
+        return self.replace(
+            observation=normalizer.normalize_obs(self.observation),
+            reward=normalizer.normalize_reward(self.reward),
+        )
 
     @property
     def view_flat(self) -> "Transition":

--- a/src/jaxnasium/algorithms/utils/_transition.py
+++ b/src/jaxnasium/algorithms/utils/_transition.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 import equinox as eqx
 import jax
@@ -29,7 +29,7 @@ class Transition(eqx.Module):
     advantage: Optional[Float[Array, "..."]] = None
 
     @property
-    def structure(self) -> PyTreeDef:
+    def structure(self) -> PyTreeDef:  # pyright: ignore[reportInvalidTypeForm]
         """
         Returns the top-level structure of the transition objects (using reward as a reference).
         This is either PyTreeDef(*) for single agents
@@ -127,9 +127,53 @@ class Transition(eqx.Module):
         return jax.tree.map(
             _merge,
             *per_agent_leaves,
-            is_leaf=lambda x: x is not per_agent_leaves
-            and not isinstance(x, Transition),
+            is_leaf=lambda x: (
+                x is not per_agent_leaves and not isinstance(x, Transition)
+            ),
         )
+
+    def scan(self, fn, init, *, reverse=False, unroll=1, **scan_kwargs) -> Any:
+        """Scan an arbitrary function over the time axis of this transition batch.
+
+        The user writes ``fn`` as if operating on **single-agent** (plain array)
+        data.  In multi-agent settings the transition is automatically
+        transposed into per-agent Transitions, scanned individually, and the
+        results are merged back.
+
+        **Arguments:**
+
+        - ``fn``: ``(carry, step: Transition) -> (carry, output)`` – written
+          for a single agent.
+        - ``init``: Initial carry value.  If the transition is multi-agent and
+          ``init``'s pytree structure already matches the agent structure, each
+          agent gets its own init leaf. If any of ``init``'s
+           first-level children match the agent structure, these are forwarded to
+            the respective agent. Otherwise ``init`` is broadcast
+          (replicated) to every agent.
+        - ``reverse``, ``unroll``, ``**scan_kwargs``: forwarded to ``jax.lax.scan``.
+
+        **Returns:**
+            ``(final_carry, outputs)`` where in multi-agent mode every output
+            has been merged back into the original per-agent pytree structure.
+        """
+
+        structure = self.structure
+
+        # ---- single-agent: plain scan ----------------------------------------
+        if structure.num_leaves <= 1:
+            return jax.lax.scan(
+                fn, init, self, reverse=reverse, unroll=unroll, **scan_kwargs
+            )
+
+        scan_fn = lambda i, x: jax.lax.scan(
+            fn, i, x, reverse=reverse, unroll=unroll, **scan_kwargs
+        )
+
+        from ._multi_agent import map_multi_agent
+
+        out = map_multi_agent(scan_fn, init, self, agent_structure=structure)
+
+        return out
 
     def make_minibatches(
         self,

--- a/src/jaxnasium/tree/__init__.py
+++ b/src/jaxnasium/tree/__init__.py
@@ -1,25 +1,16 @@
 try:
     from ._tree import (
-        tree_batch_sum as tree_batch_sum,
-        tree_concatenate as tree_concatenate,
-        tree_gather_actions as tree_gather_actions,
-        tree_get_first as tree_get_first,
-        tree_map_distribution as tree_map_distribution,
-        tree_map_one_level as tree_map_one_level,
-        tree_mean as tree_mean,
-        tree_stack as tree_stack,
-        tree_unstack as tree_unstack,
+        batch_sum as batch_sum,
+        concatenate as concatenate,
+        gather_actions as gather_actions,
+        get_first as get_first,
+        map_distribution as map_distribution,
+        map_one_level as map_one_level,
+        mean as mean,
+        split_key_like_structure as split_key_like_structure,
+        stack as stack,
+        unstack as unstack,
     )
-
-    batch_sum = tree_batch_sum
-    get_first = tree_get_first
-    gather_actions = tree_gather_actions
-    map_one_level = tree_map_one_level
-    mean = tree_mean
-    stack = tree_stack
-    unstack = tree_unstack
-    concatenate = tree_concatenate
-    map_distribution = tree_map_distribution
 
     __all__ = [
         "get_first",
@@ -29,6 +20,9 @@ try:
         "unstack",
         "concatenate",
         "map_distribution",
+        "batch_sum",
+        "gather_actions",
+        "split_key_like_structure",
     ]
 except ImportError:
     print(

--- a/src/jaxnasium/tree/_tree.py
+++ b/src/jaxnasium/tree/_tree.py
@@ -85,6 +85,10 @@ def tree_map_distribution(fn: Callable, tree, *rest):
     # any of *rest should also be converted:
     rest = tuple(r.distribution if isinstance(r, DistraxContainer) else r for r in rest)
 
+    if isinstance(tree, distrax.Joint):
+        tree = tree.distributions
+    rest = tuple(r.distributions if isinstance(r, distrax.Joint) else r for r in rest)
+
     return jax.tree.map(
         fn, tree, *rest, is_leaf=lambda x: isinstance(x, distrax.Distribution)
     )

--- a/src/jaxnasium/tree/_tree.py
+++ b/src/jaxnasium/tree/_tree.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Optional
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, PyTree, PyTreeDef
+from jaxtyping import Array, PRNGKeyArray, PyTree, PyTreeDef
 
 """
 Convenience pytree functions used in the various RL algorithms which
@@ -19,7 +19,7 @@ def _tree_size(tree):
     return sum([jnp.size(leaf) for leaf in jax.tree.leaves(tree)])
 
 
-def _tree_sum(tree: Any, axis: Optional[int | tuple[int, ...]] = None) -> Array:
+def _tree_sum(tree: Any, axis: Optional[int | tuple[int, ...]] = None):
     """
     Compute the sum of all the elements in a pytree
     If axis is provided, sums each leaf over the specified axis and
@@ -289,3 +289,29 @@ def tree_unstack(tree, *, axis=0, structure: Optional[PyTreeDef] = None):  # typ
     if structure is not None:
         return structure.unflatten(list_of_leaves)
     return list_of_leaves
+
+
+def tree_split_key_like_structure(key: PRNGKeyArray, structure: PyTreeDef):  # pyright: ignore[reportInvalidTypeForm]
+    """Split a JAX PRNGKey into a pytree of keys with the same structure as `structure`.
+
+    Similar to `optax.tree_utils.tree_split_key_like`, but operates on PyTreeDefs.
+
+    *Arguments*:
+        `key`: A PRNGKeyArray to be split.
+        `agent_structure`: A pytree structure of agents.
+    """
+    num_keys = structure.num_leaves
+    keys = list(jax.random.split(key, num_keys))
+    return jax.tree.unflatten(structure, keys)
+
+
+batch_sum = tree_batch_sum
+get_first = tree_get_first
+gather_actions = tree_gather_actions
+map_one_level = tree_map_one_level
+mean = tree_mean
+stack = tree_stack
+unstack = tree_unstack
+concatenate = tree_concatenate
+map_distribution = tree_map_distribution
+split_key_like_structure = tree_split_key_like_structure

--- a/src/jaxnasium/tree/_tree.py
+++ b/src/jaxnasium/tree/_tree.py
@@ -139,39 +139,45 @@ def tree_get_first(tree: PyTree, key: str) -> Any:
     return found_values_with_path[0][1]
 
 
-def tree_batch_sum(values, num_batch_dimensions=1):
+def tree_batch_sum(values, batch_axes: int | tuple[int, ...] = 0):
     """
     Sum over all non-batch axes of each leaf in a pytree, then sum (reduce) across leaves.
-    The batch dimension(s) is/are assumed to be the leading dimensions.
+    The batch axes(s) is/are assumed to be the leading axes.
 
     This is essentially `jaxnasium.tree.sum` or `optax.tree.sum` but with a variable
     axis argument resulting in a sum over all non-batch axes.
 
     **Arguments**:
-        values:  Pytree of JAX arrays. Every leaf must have at least `num_batch_dimensions` leading dimensions.
-        num_batch_dimensions: Number of leading batch axes (> 0).
+        values:  Pytree of JAX arrays. Every leaf must have at least `len(batch_axes)` leading dimensions.
+        batch_axes: Leading axes to exclude from the sum.
 
     **Returns**:
         A JAX array with the same shape as the batch dimensions.
 
     **Notes**:
-       - If `num_batch_dimensions == 0`, this sums the entire tree to a scalar result.
+       - For a single leaf with only batch dimensions, this is a no-op.
 
     **Example**:
         >>> tree = {"a": jnp.array([[1, 2], [3, 4]]), "b": jnp.array([[5, 6], [7, 8]])}
-        >>> tree_batch_sum(tree, num_batch_dimensions=1)
+        >>> tree_batch_sum(tree, batch_axes=0)
         Array([14, 22])
 
         >>> tree2 = {"x": jnp.ones((2, 3, 4)), "y": jnp.ones((2, 3, 4))}
-        >>> tree_batch_sum(tree2, num_batch_dimensions=2).shape
-        (2, 3)
-
-        >>> tree_batch_sum(tree2, num_batch_dimensions=0)
-        Array(48, dtype=int32)
+        >>> tree_batch_sum(tree2, batch_axes=(0, 1))
+        Array([[8., 8., 8.], [8., 8., 8.]])
 
     """
+
+    batch_axes = (batch_axes,) if isinstance(batch_axes, int) else tuple(batch_axes)
+    if batch_axes != tuple(range(len(batch_axes))):
+        raise ValueError(
+            f"batch_axes must be a leading prefix (0, 1, ..., k-1), got {batch_axes}"
+        )
+
+    num_batch_dimensions = len(batch_axes)
+
     assert all(x.ndim >= num_batch_dimensions for x in jax.tree.leaves(values)), (
-        f"Each array in the pytree must have at least `num_batch_dimensions` ({num_batch_dimensions}) dimensions, "
+        f"Each array in the pytree must have at least {num_batch_dimensions} leading batch dimensions, "
         f"but got {values}"
     )
     assert all(


### PR DESCRIPTION
- Big refactor of algorithms. Bigger seperation of the Agent (old "state") and Algorithm (trainer). This allows for cleaner automatic multi agent support. 
- Harmonized different algorithm variable names and defaults where applicable & cleaned up code.
- Removes `DistraxContainer` in favor of `distrax.Joint` and `distrax.Independent`. These are automatically used when `assume_independent` is set the in `AutoAgentOutputNet`