### PR TITLE
V1 nets

### DIFF
--- a/src/jaxnasium/algorithms/agent_networks.py
+++ b/src/jaxnasium/algorithms/agent_networks.py
@@ -1,13 +1,12 @@
 import logging
-from functools import partial
-from typing import Any, Callable
+from typing import Callable, Literal
 
 import equinox as eqx
 import jax
 from jaxtyping import Array, PRNGKeyArray, PyTree
 
 import jaxnasium as jym
-from jaxnasium.algorithms.architectures import MLP
+from jaxnasium.algorithms.architectures import CNN, MLP
 from jaxnasium.algorithms.core import (
     PyTreeObsSpaceNetwork,
     PyTreeOutputNetwork,
@@ -17,10 +16,11 @@ from jaxnasium.algorithms.types import Network, OutSizedNetwork
 
 logger = logging.getLogger(__name__)
 
-_QVALUE_OUTPUT_LAYERS = partial(
-    PyTreeOutputNetwork,
-    discrete_distribution=None,
-    continuous_distribution=None,
+_DEFAULT_ARCHITECTURE_2D = CNN.with_params(
+    out_channels=(32, 64, 64),
+    kernel_sizes=(3, 3, 2),
+    strides=(1, 1, 1),
+    padding=(0, 0, 0),
 )
 
 
@@ -36,19 +36,8 @@ Each of these consist of three components:
     - An output processor (PyTreeOutputNetwork)
         This accepts a PyTree of output spaces and builds a network per output space.
         Automtically builds a discrete or continuous output network based on the output space.
-        Returns the output of each output network in the same PyTree structure as the action space. 
+        Returns the output of each output network in the same PyTree structure as the action space.
 """
-
-
-def _split_network_kwargs(
-    network_kwargs: dict[str, Any] | None,
-) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-    network_kwargs = network_kwargs or {}
-    return (
-        network_kwargs.get("obs", {}),
-        network_kwargs.get("shared", {}),
-        network_kwargs.get("output", {}),
-    )
 
 
 class ActorNetwork(eqx.Module):
@@ -62,20 +51,35 @@ class ActorNetwork(eqx.Module):
         output_space: PyTree[jym.Space],
         *,
         key: PRNGKeyArray,
-        obs_processor: Callable[..., OutSizedNetwork] = PyTreeObsSpaceNetwork,
         body: Callable[..., OutSizedNetwork] = MLP,
-        output_layers: Callable[..., PyTreeOutputNetwork] = PyTreeOutputNetwork,
+        obs_architecture_1d: Callable[..., Network] = eqx.nn.Identity,
+        obs_architecture_2d: Callable[..., Network] = _DEFAULT_ARCHITECTURE_2D,
+        discrete_distribution: Literal["categorical"] | None = "categorical",
+        continuous_distribution: Literal["normal", "tanhnormal"] | None = "normal",
+        output_layer_type: Callable[..., Network] = eqx.nn.Linear,
+        assume_independent_output: bool = True,
         weights_init: jax.nn.initializers.Initializer = jax.nn.initializers.orthogonal(),
         bias_init: float = 0.0,
-        **network_kwargs: dict[str, Any],
     ):
-        obs_kwargs, body_kwargs, output_kwargs = _split_network_kwargs(network_kwargs)
-
         obs_key, body_key, output_key, wb_key = jax.random.split(key, 4)
-        self.obs_processor = obs_processor(obs_space, key=obs_key, **obs_kwargs)
-        self.body = body(self.obs_processor.out_features, key=body_key, **body_kwargs)
-        self.output_layers = output_layers(
-            self.body.out_features, output_space, key=output_key, **output_kwargs
+
+        self.obs_processor = PyTreeObsSpaceNetwork(
+            obs_space,
+            key=obs_key,
+            architecture_1d=obs_architecture_1d,
+            architecture_2d=obs_architecture_2d,
+        )
+
+        self.body = body(self.obs_processor.out_features, key=body_key)
+
+        self.output_layers = PyTreeOutputNetwork(
+            self.body.out_features,
+            output_space,
+            key=output_key,
+            discrete_distribution=discrete_distribution,
+            continuous_distribution=continuous_distribution,
+            layer_type=output_layer_type,
+            assume_independent=assume_independent_output,
         )
 
         (self.obs_processor, self.body, self.output_layers) = set_weight_bias(
@@ -106,23 +110,28 @@ class ValueNetwork(eqx.Module):
         obs_space: PyTree[jym.Space],
         *,
         key: PRNGKeyArray,
-        obs_processor: Callable[..., OutSizedNetwork] = PyTreeObsSpaceNetwork,
         body: Callable[..., OutSizedNetwork] = MLP,
-        output_layers: Callable[..., Network] = eqx.nn.Linear,
+        obs_architecture_1d: Callable[..., Network] = eqx.nn.Identity,
+        obs_architecture_2d: Callable[..., Network] = _DEFAULT_ARCHITECTURE_2D,
+        output_layer_type: Callable[..., Network] = eqx.nn.Linear,
         weights_init: jax.nn.initializers.Initializer = jax.nn.initializers.orthogonal(),
         bias_init: float = 0.0,
-        **network_kwargs: dict[str, Any],
     ):
-        obs_kwargs, body_kwargs, output_kwargs = _split_network_kwargs(network_kwargs)
-
         obs_key, body_key, output_key, wb_key = jax.random.split(key, 4)
-        self.obs_processor = obs_processor(obs_space, key=obs_key, **obs_kwargs)
-        self.body = body(self.obs_processor.out_features, key=body_key, **body_kwargs)
-        self.output_layers = output_layers(
+
+        self.obs_processor = PyTreeObsSpaceNetwork(
+            obs_space,
+            key=obs_key,
+            architecture_1d=obs_architecture_1d,
+            architecture_2d=obs_architecture_2d,
+        )
+
+        self.body = body(self.obs_processor.out_features, key=body_key)
+
+        self.output_layers = output_layer_type(
             in_features=self.body.out_features,
             out_features=1,
             key=output_key,
-            **output_kwargs,
         )
 
         (self.obs_processor, self.body, self.output_layers) = set_weight_bias(
@@ -154,12 +163,12 @@ class QValueNetwork(eqx.Module):
         output_space: PyTree[jym.Space],
         *,
         key: PRNGKeyArray,
-        obs_processor: Callable[..., OutSizedNetwork] = PyTreeObsSpaceNetwork,
         body: Callable[..., OutSizedNetwork] = MLP,
-        output_layers: Callable[..., PyTreeOutputNetwork] = _QVALUE_OUTPUT_LAYERS,
+        obs_architecture_1d: Callable[..., Network] = eqx.nn.Identity,
+        obs_architecture_2d: Callable[..., Network] = _DEFAULT_ARCHITECTURE_2D,
+        output_layer_type: Callable[..., Network] = eqx.nn.Linear,
         weights_init: jax.nn.initializers.Initializer = jax.nn.initializers.orthogonal(),
         bias_init: float = 0.0,
-        **network_kwargs: dict[str, Any],
     ):
         is_continuous = [isinstance(s, jym.Box) for s in jax.tree.leaves(output_space)]
         if any(is_continuous):
@@ -168,16 +177,22 @@ class QValueNetwork(eqx.Module):
         else:
             self.include_action_in_input = False
 
-        obs_kwargs, body_kwargs, output_kwargs = _split_network_kwargs(network_kwargs)
-
         obs_key, body_key, output_key, wb_key = jax.random.split(key, 4)
-        self.obs_processor = obs_processor(obs_space, key=obs_key, **obs_kwargs)
-        self.body = body(self.obs_processor.out_features, key=body_key, **body_kwargs)
-        self.output_layers = output_layers(
+
+        self.obs_processor = PyTreeObsSpaceNetwork(
+            obs_space,
+            key=obs_key,
+            architecture_1d=obs_architecture_1d,
+            architecture_2d=obs_architecture_2d,
+        )
+
+        self.body = body(self.obs_processor.out_features, key=body_key)
+
+        self.output_layers = PyTreeOutputNetwork.with_raw_outputs()(
             self.body.out_features,
             output_space,
             key=output_key,
-            **output_kwargs,
+            layer_type=output_layer_type,
         )
 
         (self.obs_processor, self.body, self.output_layers) = set_weight_bias(

--- a/src/jaxnasium/algorithms/agent_networks.py
+++ b/src/jaxnasium/algorithms/agent_networks.py
@@ -96,15 +96,15 @@ class ActorNetwork(eqx.Module):
             bias_init=bias_init,
         )
 
-    def __call__(self, x):
+    def __call__(self, x, *, key: PRNGKeyArray | None = None):
         action_mask = None
         if isinstance(x, jym.AgentObservation):
             action_mask = x.action_mask
             x = x.observation
 
-        x = self.obs_processor(x)
-        x = self.body(x)
-        return self.output_layers(x, action_mask=action_mask)
+        x = self.obs_processor(x, key=key)
+        x = self.body(x, key=key)
+        return self.output_layers(x, action_mask=action_mask, key=key)
 
 
 class ValueNetwork(eqx.Module):
@@ -143,13 +143,13 @@ class ValueNetwork(eqx.Module):
             bias_init=bias_init,
         )
 
-    def __call__(self, x):
+    def __call__(self, x, *, key: PRNGKeyArray | None = None):
         if isinstance(x, jym.AgentObservation):
             x = x.observation
 
-        x = self.obs_processor(x)
-        x = self.body(x)
-        return self.output_layers(x).squeeze(-1)
+        x = self.obs_processor(x, key=key)
+        x = self.body(x, key=key)
+        return self.output_layers(x, key=key).squeeze(-1)
 
 
 class QValueNetwork(eqx.Module):
@@ -198,7 +198,9 @@ class QValueNetwork(eqx.Module):
             bias_init=bias_init,
         )
 
-    def __call__(self, x, action=None) -> Array | PyTree[Array]:
+    def __call__(
+        self, x, action=None, *, key: PRNGKeyArray | None = None
+    ) -> Array | PyTree[Array]:
         action_mask = None
         if isinstance(x, jym.AgentObservation):
             action_mask = x.action_mask
@@ -208,9 +210,9 @@ class QValueNetwork(eqx.Module):
             assert action is not None, "Action not provided in continuous Q network."
             x = {"_OBSERVATION": x, "_ACTION": action}
 
-        x = self.obs_processor(x)
-        x = self.body(x)
-        return self.output_layers(x, action_mask=action_mask)
+        x = self.obs_processor(x, key=key)
+        x = self.body(x, key=key)
+        return self.output_layers(x, action_mask=action_mask, key=key)
 
 
 AdvantageNetwork = QValueNetwork

--- a/src/jaxnasium/algorithms/agent_networks.py
+++ b/src/jaxnasium/algorithms/agent_networks.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import Any, Callable, Protocol
+from typing import Any, Callable
 
 import equinox as eqx
 import jax
@@ -13,6 +13,7 @@ from jaxnasium.algorithms.core import (
     PyTreeOutputNetwork,
     set_weight_bias,
 )
+from jaxnasium.algorithms.types import Network, OutSizedNetwork
 
 logger = logging.getLogger(__name__)
 
@@ -37,18 +38,6 @@ Each of these consist of three components:
         Automtically builds a discrete or continuous output network based on the output space.
         Returns the output of each output network in the same PyTree structure as the action space. 
 """
-
-
-class Network(Protocol):
-    """Any module with a __call__ defined"""
-
-    def __call__(self, *args, **kwargs) -> Any: ...
-
-
-class OutSizedNetwork(Network, Protocol):
-    """Any module with a __call__ defined and an out_features attribute"""
-
-    out_features: int
 
 
 def _split_network_kwargs(

--- a/src/jaxnasium/algorithms/architectures/bronet.py
+++ b/src/jaxnasium/algorithms/architectures/bronet.py
@@ -26,12 +26,12 @@ class _BroNetBlock(eqx.Module):
         self.in_features = shape
         self.out_features = shape
 
-    def __call__(self, x):
-        _x = self.layers[0](x)
-        _x = self.layers[1](_x)
+    def __call__(self, x, *, key: PRNGKeyArray | None = None):
+        _x = self.layers[0](x, key=key)
+        _x = self.layers[1](_x, key=key)
         _x = jax.nn.relu(_x)
-        _x = self.layers[2](_x)
-        _x = self.layers[3](_x)
+        _x = self.layers[2](_x, key=key)
+        _x = self.layers[3](_x, key=key)
         return x + _x
 
 
@@ -71,13 +71,13 @@ class BroNet(eqx.Module):
         for i in range(1, depth + 1):
             self.layers.append(_BroNetBlock(width_size, key=keys[i]))
 
-    def __call__(self, x):
-        x = self.layers[0](x)  # dense
-        x = self.layers[1](x)  # layernorm
+    def __call__(self, x, *, key: PRNGKeyArray | None = None):
+        x = self.layers[0](x, key=key)  # dense
+        x = self.layers[1](x, key=key)  # layernorm
         x = jax.nn.relu(x)
         # then the bronet blocks:
         for block in self.layers[2:]:
-            x = block(x)
+            x = block(x, key=key)
         return x
 
     @classmethod

--- a/src/jaxnasium/algorithms/architectures/cnn.py
+++ b/src/jaxnasium/algorithms/architectures/cnn.py
@@ -86,12 +86,12 @@ class CNN(eqx.Module):
         )
         self.out_features = out_shape[0]
 
-    def __call__(self, x):
+    def __call__(self, x, *, key: PRNGKeyArray | None = None):
         if self.channels_axis == "last":
             x = jnp.moveaxis(x, -1, 0)
 
         for layer in self.layers:
-            x = self.activation(layer(x))
+            x = self.activation(layer(x, key=key))
         x = jnp.reshape(x, -1)
         return x
 

--- a/src/jaxnasium/algorithms/architectures/mlp.py
+++ b/src/jaxnasium/algorithms/architectures/mlp.py
@@ -43,11 +43,10 @@ class MLP(eqx.Module):
             )
             in_features = hidden_dim
 
-    def __call__(self, x):
+    def __call__(self, x, *, key: PRNGKeyArray | None = None):
         for layer in self.layers[:-1]:
-            x = self.activation(layer(x))
-        x = self.layers[-1](x)
-        return x
+            x = self.activation(layer(x, key=key))
+        return self.layers[-1](x, key=key)
 
     @classmethod
     def with_params(

--- a/src/jaxnasium/algorithms/core/_input_output.py
+++ b/src/jaxnasium/algorithms/core/_input_output.py
@@ -223,11 +223,11 @@ class PyTreeObsSpaceNetwork(eqx.Module):
         f = lambda obs: jnp.atleast_1d(self(obs))
         self.out_features = jax.eval_shape(f, dummy_obs).shape[0]
 
-    def __call__(self, x):
+    def __call__(self, x, *, key: PRNGKeyArray | None = None):
         x = jax.tree.map(lambda x: jnp.asarray(x, dtype=jnp.float32), x)
 
         outputs = jax.tree.map(
-            lambda layer, x: layer(x),
+            lambda layer, x: layer(x, key=key),
             self.networks,
             x,
             is_leaf=_is_callable_module,
@@ -336,12 +336,12 @@ class DiscreteHead(eqx.Module):
             else _resolve_discrete_distribution(distribution, dtype=output_space.dtype)
         )
 
-    def __call__(self, x, action_mask=None):
+    def __call__(self, x, action_mask=None, *, key: PRNGKeyArray | None = None):
         if len(self.layers) == 1:  # single-dimensional output space
-            logits = self.layers[0](x)
+            logits = self.layers[0](x, key=key)
         else:
             stacked_layers = jym.tree.stack(self.layers)
-            logits = jax.vmap(lambda layer: layer(x))(stacked_layers)
+            logits = jax.vmap(lambda layer: layer(x, key=key))(stacked_layers)
 
         if action_mask is not None:
             logits = _apply_action_mask(logits, action_mask)
@@ -394,15 +394,15 @@ class ContinuousHead(eqx.Module):
             lambda o, k: layer_type(in_features, o, key=k), num_outputs, keys
         )
 
-    def __call__(self, x, action_mask=None):
+    def __call__(self, x, action_mask=None, *, key: PRNGKeyArray | None = None):
         if action_mask is not None:
             logger.debug("Action mask provided for continuous space, ignoring.")
 
         if self.output_shape == ():
-            out = self.layers[0](x)  # scalar output
+            out = self.layers[0](x, key=key)  # scalar output
         else:
             stacked_layers = jym.tree.stack(self.layers)
-            out = jax.vmap(lambda layer: layer(x))(stacked_layers)
+            out = jax.vmap(lambda layer: layer(x, key=key))(stacked_layers)
 
         mean = out[..., 0].reshape(self.output_shape)
         log_std = jnp.clip(
@@ -448,12 +448,12 @@ class QHead(eqx.Module):
         else:
             raise ValueError(f"Unsupported output space: {output_space}")
 
-    def __call__(self, x, action_mask=None):
+    def __call__(self, x, action_mask=None, *, key: PRNGKeyArray | None = None):
         if self.mode == "discrete":
-            return self.layer(x, action_mask=action_mask)
+            return self.layer(x, action_mask=action_mask, key=key)
         if action_mask is not None:
             logger.debug("Action mask provided for continuous space, ignoring.")
-        return self.layer(x).squeeze()
+        return self.layer(x, key=key).squeeze()
 
 
 class PyTreeOutputNetwork(eqx.Module):
@@ -550,14 +550,14 @@ class PyTreeOutputNetwork(eqx.Module):
             )
         return has_continuous_q_head
 
-    def __call__(self, x, action_mask=None):
+    def __call__(self, x, action_mask=None, *, key: PRNGKeyArray | None = None):
         if action_mask is None:  # Dummy action mask if not provided
             action_mask = jax.tree.map(
                 lambda _: None, self.heads, is_leaf=_is_callable_module
             )
 
         outputs = jax.tree.map(
-            lambda head, mask: head(x, action_mask=mask),
+            lambda head, mask: head(x, action_mask=mask, key=key),
             self.heads,
             action_mask,
             is_leaf=_is_callable_module,

--- a/src/jaxnasium/algorithms/core/_input_output.py
+++ b/src/jaxnasium/algorithms/core/_input_output.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import Any, Callable, List, Literal, Protocol, Sequence
+from typing import Any, Callable, List, Literal
 
 import distrax
 import equinox as eqx
@@ -13,31 +13,15 @@ from jaxtyping import Array, PRNGKeyArray, PyTree
 import jaxnasium as jym
 
 from ..architectures import CNN, Identity
+from ..types import (
+    ContinuousSpaceLike,
+    DiscreteSpaceLike,
+    Network,
+    SpaceLike,
+)
 from ._distributions import TanhNormalFactory
 
 logger = logging.getLogger(__name__)
-
-
-class SpaceLike(Protocol):
-    shape: tuple[int, ...]
-    sample: Callable[[PRNGKeyArray], Array]
-    dtype: jnp.dtype
-
-
-class DiscreteSpaceLike(SpaceLike, Protocol):
-    n: int | None = None
-    nvec: Sequence[int] | None = None
-
-
-class ContinuousSpaceLike(SpaceLike, Protocol):
-    low: Array
-    high: Array
-
-
-class Network(Protocol):
-    """Any module with a __call__ defined"""
-
-    def __call__(self, *args, **kwargs) -> Any: ...
 
 
 def _is_space_discrete(space: SpaceLike) -> bool:

--- a/src/jaxnasium/algorithms/core/_input_output.py
+++ b/src/jaxnasium/algorithms/core/_input_output.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import numpy as np
 import optax
 from jaxtyping import Array, PRNGKeyArray, PyTree
+from typing_extensions import Self
 
 import jaxnasium as jym
 
@@ -150,21 +151,12 @@ class PyTreeObsSpaceNetwork(eqx.Module):
             strides=(1, 1, 1),
             padding=(0, 0, 0),
         ),
-        network_kwargs_1d: dict[str, Any] | None = {},
-        network_kwargs_2d: dict[str, Any] | None = {},
     ):
-        kwargs_1d = network_kwargs_1d or {}
-        kwargs_2d = network_kwargs_2d or {}
-
         def create_obs_processor(key: PRNGKeyArray, obs_space: SpaceLike):
             if obs_space.shape == () or len(obs_space.shape) == 1:
-                return self._create_1d_obs_processor(
-                    key, obs_space, architecture_1d, kwargs_1d
-                )
+                return self._create_1d_obs_processor(key, obs_space, architecture_1d)
             elif len(obs_space.shape) == 3:
-                return self._create_2d_obs_processor(
-                    key, obs_space, architecture_2d, kwargs_2d
-                )
+                return self._create_2d_obs_processor(key, obs_space, architecture_2d)
             elif len(obs_space.shape) == 2:
                 raise ValueError(
                     f"2D observation space shape without a channel axis ({obs_space.shape}) detected. "
@@ -223,7 +215,6 @@ class PyTreeObsSpaceNetwork(eqx.Module):
         key: PRNGKeyArray,
         obs_space: SpaceLike,
         architecture: Callable[..., Network],
-        architecture_kwargs: dict[str, Any],
     ):
         try:
             if obs_space.shape == ():
@@ -234,7 +225,7 @@ class PyTreeObsSpaceNetwork(eqx.Module):
                 raise ValueError(
                     f"Unsupported observation space shape: {obs_space.shape}"
                 )
-            return architecture(in_features, key=key, **architecture_kwargs)
+            return architecture(in_features, key=key)
         except AttributeError:
             raise ValueError(f"Unsupported observation space {obs_space}")
 
@@ -243,7 +234,6 @@ class PyTreeObsSpaceNetwork(eqx.Module):
         key: PRNGKeyArray,
         obs_space: SpaceLike,
         architecture: Callable[..., Network],
-        architecture_kwargs: dict[str, Any],
     ):
         try:
             if len(obs_space.shape) == 3:
@@ -252,7 +242,6 @@ class PyTreeObsSpaceNetwork(eqx.Module):
                     obs_space.shape,
                     key=key,
                     channels_axis=channels_axis,
-                    **architecture_kwargs,
                 )
             raise ValueError(f"Unsupported observation space shape: {obs_space.shape}")
         except AttributeError:
@@ -277,6 +266,24 @@ class PyTreeObsSpaceNetwork(eqx.Module):
         raise ValueError(
             f"Cannot infer channel axis from shape {obs_space.shape}. "
             "Pass `channels_axis` explicitly  ('first' or 'last')."
+        )
+
+    @classmethod
+    def with_params(
+        cls,
+        *,
+        architecture_1d: Callable[..., Network] = Identity,
+        architecture_2d: Callable[..., Network] = CNN.with_params(
+            out_channels=(32, 64, 64),
+            kernel_sizes=(3, 3, 2),
+            strides=(1, 1, 1),
+            padding=(0, 0, 0),
+        ),
+    ) -> Callable[..., Self]:
+        return partial(
+            cls,
+            architecture_1d=architecture_1d,
+            architecture_2d=architecture_2d,
         )
 
 
@@ -558,3 +565,32 @@ class PyTreeOutputNetwork(eqx.Module):
                 return distrax.Joint(outputs)
 
         return outputs
+
+    @classmethod
+    def with_params(
+        cls,
+        *,
+        discrete_distribution: Literal["categorical"] | None = "categorical",
+        continuous_distribution: Literal["normal", "tanhnormal"] | None = "normal",
+        layer_type: Callable[..., Network] = eqx.nn.Linear,
+        assume_independent: bool = True,
+    ) -> Callable[..., Self]:
+        return partial(
+            cls,
+            discrete_distribution=discrete_distribution,
+            continuous_distribution=continuous_distribution,
+            layer_type=layer_type,
+            assume_independent=assume_independent,
+        )
+
+    @classmethod
+    def with_raw_outputs(
+        cls, *, layer_type: Callable[..., Network] = eqx.nn.Linear
+    ) -> Callable[..., Self]:
+        """Create a network without a distribution output, instead returning the raw
+        outputs. E.g. for Q-values."""
+        return cls.with_params(
+            discrete_distribution=None,
+            continuous_distribution=None,
+            layer_type=layer_type,
+        )

--- a/src/jaxnasium/algorithms/sac.py
+++ b/src/jaxnasium/algorithms/sac.py
@@ -54,13 +54,9 @@ class SACAgent(RLAgent):
     def __init__(self, key, env: Environment, trainer: "SAC"):
         actor_key, critics_key = jax.random.split(key, 2)
 
-        # If the continuous distribution is not specified, use "tanhnormal" for SAC
-        output_kwargs = trainer.actor_kwargs.get("output", {})
-        cont_dist_output = output_kwargs.get("continuous_distribution", "tanhnormal")
-        output_kwargs["continuous_distribution"] = cont_dist_output
-        actor_kwargs = trainer.actor_kwargs.copy()
-        actor_kwargs["output"] = output_kwargs
-
+        # Set default continuous distribution to tanhnormal if not specified
+        actor_kwargs = dict(trainer.actor_kwargs)
+        actor_kwargs.setdefault("continuous_distribution", "tanhnormal")
         self.actor = ActorNetwork(
             env.observation_space,
             env.action_space,

--- a/src/jaxnasium/algorithms/types.py
+++ b/src/jaxnasium/algorithms/types.py
@@ -1,0 +1,32 @@
+from typing import Any, Callable, Protocol, Sequence
+
+import jax.numpy as jnp
+from jaxtyping import Array, PRNGKeyArray
+
+
+class SpaceLike(Protocol):
+    shape: tuple[int, ...]
+    sample: Callable[[PRNGKeyArray], Array]
+    dtype: jnp.dtype
+
+
+class DiscreteSpaceLike(SpaceLike, Protocol):
+    n: int | None = None
+    nvec: Sequence[int] | None = None
+
+
+class ContinuousSpaceLike(SpaceLike, Protocol):
+    low: Array
+    high: Array
+
+
+class Network(Protocol):
+    """Any module with a __call__ defined."""
+
+    def __call__(self, *args, **kwargs) -> Any: ...
+
+
+class OutSizedNetwork(Network, Protocol):
+    """Any module with a __call__ defined and an out_features attribute."""
+
+    out_features: int

--- a/tests/_consts.py
+++ b/tests/_consts.py
@@ -1,6 +1,7 @@
 from typing import Type
 
 from jaxnasium.algorithms import DQN, PPO, PQN, SAC  # noqa: F401
+from jaxnasium.algorithms.architectures import MLP
 from jaxnasium.wrappers import Wrapper
 
 DISCRETE_ALGS = [PPO, PQN, DQN, SAC]
@@ -15,8 +16,8 @@ AGENT_MIN_CONFIG = {
     "log_function": None,
     "normalize_observations": False,
     "normalize_rewards": False,
-    "actor_kwargs": {"shared": {"hidden_sizes": (8,)}},
-    "critic_kwargs": {"shared": {"hidden_sizes": (8,)}},
+    "actor_kwargs": {"body": MLP.with_params(hidden_sizes=(8,))},
+    "critic_kwargs": {"body": MLP.with_params(hidden_sizes=(8,))},
 }
 
 


### PR DESCRIPTION

- All network modules (`MLP`, `CNN`, `BroNet`, etc.) and output heads now consistently accept an optional `key` argument in their `__call__` methods, aligning with equinox's API and supporting possible stochastic call methods.
- Some type and protocol refactoring
- Alter inputs for the Agent Networks